### PR TITLE
should be `testmain.cpp` in line 7 cmakelist for unitest

### DIFF
--- a/cpp/source/unittest/CMakeLists.txt
+++ b/cpp/source/unittest/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For testing on the function/class level.
 
 add_executable(unittests
-        testMain.cpp
+        testmain.cpp
         publicApi.test.cpp
         privateApi.test.cpp
         utils.test.cpp.hpp


### PR DESCRIPTION
there is a typo meant to be corrected yesterday. Now I pushed the corrected cmakelist
@sdmg15 @dendisuhubdy 