### PR TITLE
feat(async-sdk-cpp): add static assert to all callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@
 # IDE
 *.idea
 *.prefs
-java/.metadata/.lock
-java/.metadata/.log
 *.version
 *.index
 *.tree
@@ -47,9 +45,4 @@ java/.metadata/.log
 *.ini
 *.resources
 *.xml
-java/.metadata/.plugins/org.eclipse.egit.core/.org.eclipse.egit.core.cmp/.project
-java/.metadata/.plugins/org.eclipse.jdt.core/assumedExternalFilesCache
-java/.metadata/.plugins/org.eclipse.jdt.core/externalFilesCache
-java/.metadata/.plugins/org.eclipse.jdt.core/nonChainingJarsCache
-java/.metadata/.plugins/org.eclipse.ui.intro/introstate
->>>>>>> 3c17960f08fdea3b0adbb49e2b80d8fad0b70b66
+java/*

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,23 @@
 
 # IDE
 *.idea
+*.prefs
+java/.metadata/.lock
+java/.metadata/.log
+*.version
+*.index
+*.tree
+*.xmi
+*.dat
+*.ser
+*.log
+*.setup
+*.ini
+*.resources
+*.xml
+java/.metadata/.plugins/org.eclipse.egit.core/.org.eclipse.egit.core.cmp/.project
+java/.metadata/.plugins/org.eclipse.jdt.core/assumedExternalFilesCache
+java/.metadata/.plugins/org.eclipse.jdt.core/externalFilesCache
+java/.metadata/.plugins/org.eclipse.jdt.core/nonChainingJarsCache
+java/.metadata/.plugins/org.eclipse.ui.intro/introstate
+>>>>>>> 3c17960f08fdea3b0adbb49e2b80d8fad0b70b66

--- a/.gitignore
+++ b/.gitignore
@@ -33,22 +33,3 @@
 
 # IDE
 *.idea
-*.prefs
-java/.metadata/.lock
-java/.metadata/.log
-*.version
-*.index
-*.tree
-*.xmi
-*.dat
-*.ser
-*.log
-*.setup
-*.ini
-*.resources
-*.xml
-java/.metadata/.plugins/org.eclipse.egit.core/.org.eclipse.egit.core.cmp/.project
-java/.metadata/.plugins/org.eclipse.jdt.core/assumedExternalFilesCache
-java/.metadata/.plugins/org.eclipse.jdt.core/externalFilesCache
-java/.metadata/.plugins/org.eclipse.jdt.core/nonChainingJarsCache
-java/.metadata/.plugins/org.eclipse.ui.intro/introstate

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -8,7 +8,7 @@ The Dispatcher class is responsible to send request. Each end point has to proce
 The API URL is retrieved from the environment variable `URL_API_BITWYRE`, but if you do not set it, a default one
 pointing to our production cluster will be used.
 
-# Building from source
+# Building from source 
 
 ## Requirements
 
@@ -34,9 +34,9 @@ The `create` command will update your local cache and you can run the examples w
 --->
 In order to build the test suite add `-DBUILD_TESTING` definition.
 
-# Package Managers
+# Package Managers 
 
-## Conan
+## Conan 
 
 Add our remote https://conan.bitwyre.id/artifactory/api/conan/bitwyre to your list of remotes
 
@@ -46,9 +46,9 @@ conan remote add bitwyre  https://conan.bitwyre.id/artifactory/api/conan/bitwyre
 
 Then inside your `conanfile.py` or `conanfile.txt` add `bitwyresdk/[>=1.0]`
 
-## Vckpg
+## Vckpg 
 
-Coming Soon
+Coming Soon 
 
 # Example of usage Public API
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -8,7 +8,7 @@ The Dispatcher class is responsible to send request. Each end point has to proce
 The API URL is retrieved from the environment variable `URL_API_BITWYRE`, but if you do not set it, a default one
 pointing to our production cluster will be used.
 
-# Building from source 
+# Building from source
 
 ## Requirements
 
@@ -34,9 +34,9 @@ The `create` command will update your local cache and you can run the examples w
 --->
 In order to build the test suite add `-DBUILD_TESTING` definition.
 
-# Package Managers 
+# Package Managers
 
-## Conan 
+## Conan
 
 Add our remote https://conan.bitwyre.id/artifactory/api/conan/bitwyre to your list of remotes
 
@@ -46,9 +46,9 @@ conan remote add bitwyre  https://conan.bitwyre.id/artifactory/api/conan/bitwyre
 
 Then inside your `conanfile.py` or `conanfile.txt` add `bitwyresdk/[>=1.0]`
 
-## Vckpg 
+## Vckpg
 
-Coming Soon 
+Coming Soon
 
 # Example of usage Public API
 

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -27,8 +27,8 @@ class bitwyresdkCpp(ConanFile):
 
     def requirements(self):
         if tools.get_env("CONAN_RUN_TESTS"):
-            self.requires("catch2/2.13.6@bitwyre/stable")
-            self.requires("gtest/cci.20210126@bitwyre/stable")
+        self.requires("catch2/2.13.6@bitwyre/stable")
+        self.requires("gtest/cci.20210126@bitwyre/stable")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -27,8 +27,8 @@ class bitwyresdkCpp(ConanFile):
 
     def requirements(self):
         if tools.get_env("CONAN_RUN_TESTS"):
-        self.requires("catch2/2.13.6@bitwyre/stable")
-        self.requires("gtest/cci.20210126@bitwyre/stable")
+            self.requires("catch2/2.13.6@bitwyre/stable")
+            self.requires("gtest/cci.20210126@bitwyre/stable")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+#include <future>
 using namespace Bitwyre::Types::Private;
 using namespace Bitwyre::Details;
 using AsyncAccountBalanceResponse = std::future<AccountBalanceResponse>;
@@ -14,7 +15,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountBalanceRequest& request) noexcept
-        -> AccountBalanceResponse {
+        -> AsyncAccountBalanceResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -3,6 +3,8 @@
 using namespace Bitwyre::Types::Private;
 using namespace Bitwyre::Details;
 using AsyncAccountBalanceResponse = std::future<AccountBalanceResponse>;
+using Callback = std::function<void(const AccountBalanceResponse&)>;
+
 namespace Bitwyre::Rest::Private {
   using json = nlohmann::json;
 
@@ -12,7 +14,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/spotbalance";
     }
 
-    using Callback = std::function<void(const AccountBalanceResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const AccountBalanceRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -3,12 +3,13 @@
 using namespace Bitwyre::Types::Private;
 using namespace Bitwyre::Details;
 using AsyncAccountBalanceResponse = std::future<AccountBalanceResponse>;
-using Callback = std::function<void(const AccountBalanceResponse&)>;
 
 namespace Bitwyre::Rest::Private {
   using json = nlohmann::json;
 
   struct AccountBalance {
+
+    using Callback = std::function<void(const AccountBalanceResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/account/spotbalance";

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -12,6 +12,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/spotbalance";
     }
 
+    using Callback = std::function<void(const AccountBalanceResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const AccountBalanceRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountBalanceRequest& request) noexcept
         -> AsyncAccountBalanceResponse {

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -17,6 +17,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const AccountBalanceRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), AccountBalanceResponse>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -14,7 +14,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountBalanceRequest& request) noexcept
-        -> AsyncAccountBalanceResponse {
+        -> AccountBalanceResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-#include <future>
 using namespace Bitwyre::Types::Private;
 using namespace Bitwyre::Details;
 using AsyncAccountBalanceResponse = std::future<AccountBalanceResponse>;

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../../details/Types.hpp"
-#include<future>
+#include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncAccountStatementResponse = std::future<AccountStatementResponse>;
 

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -12,6 +12,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/statement";
     }
 
+    using Callback = std::function<void(const AsyncAccountStatementResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const AccountStatementRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountStatementRequest& request) noexcept
         -> AsyncAccountStatementResponse {

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -21,7 +21,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountStatementRequest& request) noexcept
-        -> AccountStatementResponse {
+        -> AsyncAccountStatementResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncAccountStatementResponse = std::future<AccountStatementResponse>;
-using Callback = std::function<void(const AccountStatementResponse&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct AccountStatement {
+
+    using Callback = std::function<void(const AccountStatementResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/account/statement";

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -12,7 +12,7 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/statement";
     }
 
-    using Callback = std::function<void(const AsyncAccountStatementResponse&)>;
+    using Callback = std::function<void(const AccountStatementResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const AccountStatementRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -11,10 +11,17 @@ namespace Bitwyre::Rest::Private {
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/account/statement";
     }
+//
+//    template<typename Dispatcher = Dispatcher>
+//    [[nodiscard]] static auto
+//    getAsync(const AccountStatementRequest& request) noexcept
+//        -> AccountStatementResponse {
+//      return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
+//    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountStatementRequest& request) noexcept
-        -> AsyncAccountStatementResponse {
+        -> AccountStatementResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "../../details/Types.hpp"
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Types::Private;

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "../../details/Dispatcher.hpp"
-
+#include "../../details/Types.hpp"
+#include<future>
 using namespace Bitwyre::Types::Private;
 using AsyncAccountStatementResponse = std::future<AccountStatementResponse>;
 
@@ -11,13 +11,6 @@ namespace Bitwyre::Rest::Private {
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/account/statement";
     }
-//
-//    template<typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto
-//    getAsync(const AccountStatementRequest& request) noexcept
-//        -> AccountStatementResponse {
-//      return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
-//    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountStatementRequest& request) noexcept

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const AccountStatementRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), AccountStatementResponse>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -74,7 +74,6 @@ namespace Bitwyre::Rest::Private {
 
       for (auto it = withdrawals.cbegin(); it != withdrawals.cend(); ++it) {
         std::vector<AccountStatementElement> assetDeposits;
-
         for (const auto& withdrawal : it.value()) {
           AccountStatementElement statementElement{};
           statementElement.fee = withdrawal["fee"].get<long double>();
@@ -104,4 +103,4 @@ namespace Bitwyre::Rest::Private {
       return statementResponse;
     }
   };
-} // namespace Bitwyre::Rest::Private
+}// namespace Bitwyre::Rest::Private

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -3,6 +3,7 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncAccountStatementResponse = std::future<AccountStatementResponse>;
+using Callback = std::function<void(const AccountStatementResponse&)>;
 
 namespace Bitwyre::Rest::Private {
 
@@ -12,7 +13,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/statement";
     }
 
-    using Callback = std::function<void(const AccountStatementResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const AccountStatementRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncExecutionReport = std::future<ExecutionReport>;
-using Callback = std::function<void(const ExecutionReport&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct CancelOrder {
+
+    using Callback = std::function<void(const ExecutionReport&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders/cancel";

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(Callback cb, const CancelOrderRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), ExecutionReport>);
       auto result = delAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(const CancelOrderRequest& request) noexcept
-        -> AsyncExecutionReport {
+        -> ExecutionReport {
       return std::async(std::launch::async, [&request](){return del<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Types::Private;
 using AsyncExecutionReport = std::future<ExecutionReport>;
 namespace Bitwyre::Rest::Private {
@@ -13,7 +12,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(const CancelOrderRequest& request) noexcept
-        -> ExecutionReport {
+        -> AsyncExecutionReport {
       return std::async(std::launch::async, [&request](){return del<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -14,7 +14,7 @@ namespace Bitwyre::Rest::Private {
     using Callback = std::function<void(const ExecutionReport&)>;
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(Callback cb, const CancelOrderRequest& request) noexcept -> void {
-      auto result = getAsync(request);
+      auto result = delAsync(request);
       return cb(result.get());
     }
 

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/cancel";
     }
 
+    using Callback = std::function<void(const ExecutionReport&)>;
+    template <typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto delAsync(Callback cb, const CancelOrderRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(const CancelOrderRequest& request) noexcept
         -> AsyncExecutionReport {

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncExecutionReport = std::future<ExecutionReport>;
+using Callback = std::function<void(const ExecutionReport&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct CancelOrder {
@@ -11,7 +13,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/cancel";
     }
 
-    using Callback = std::function<void(const ExecutionReport&)>;
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(Callback cb, const CancelOrderRequest& request) noexcept -> void {
       auto result = delAsync(request);

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -84,7 +84,6 @@ namespace Bitwyre::Rest::Private {
 
       executionReport.cancelOnDisconnect =
           static_cast<bool>(result["cancelondisconnect"].get<short>());
-
       return executionReport;
     }
   };

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncExecutionReport = std::future<ExecutionReport>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncCloseOrdersResponse = std::future<ClosedOrdersResponse>;
-using Callback = std::function<void(const ClosedOrdersResponse&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct ClosedOrders {
+
+    using Callback = std::function<void(const ClosedOrdersResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders/closed";

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncCloseOrdersResponse = std::future<ClosedOrdersResponse>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/closed";
     }
 
+    using Callback = std::function<void(const ClosedOrdersResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrderRequest& request) noexcept -> void{
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const ClosedOrdersRequest& request) noexcept
         -> AsyncCloseOrdersResponse {

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const ClosedOrdersRequest& request) noexcept
-        -> AsyncCloseOrdersResponse {
+        -> ClosedOrdersResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrdersRequest& request) noexcept -> void{
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), ClosedOrdersResponse>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Types::Private;
 using AsyncCloseOrdersResponse = std::future<ClosedOrdersResponse>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     using Callback = std::function<void(const ClosedOrdersResponse&)>;
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrderRequest& request) noexcept -> void{
+    [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrdersRequest& request) noexcept -> void{
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const ClosedOrdersRequest& request) noexcept
-        -> ClosedOrdersResponse {
+        -> AsyncCloseOrdersResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -72,7 +72,6 @@ namespace Bitwyre::Rest::Private {
           } else {
             executionReport.ordRejReason = 0;
           }
-
           executionReport.ordStatusReqId =
               closedOrder["ordstatusReqID"].get<std::string>();
           executionReport.origcliId =

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncCloseOrdersResponse = std::future<ClosedOrdersResponse>;
+using Callback = std::function<void(const ClosedOrdersResponse&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct ClosedOrders {
@@ -11,7 +13,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/closed";
     }
 
-    using Callback = std::function<void(const ClosedOrdersResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrdersRequest& request) noexcept -> void{
       auto result = getAsync(request);

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -2,7 +2,7 @@
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Types::Private;
-using AsyncNewOrderRequest = std::future<NewOrderRequest>;
+using AsyncNewOrderResponse = std::future<NewOrderResponse>;
 namespace Bitwyre::Rest::Private {
 
   struct NewOrder {
@@ -14,13 +14,13 @@ namespace Bitwyre::Rest::Private {
     using Callback = std::function<void(const NewOrderResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(Callback cb, const NewOrderRequest& request) noexcept -> void {
-      auto result = getAsync(request);
+      auto result = postAsync(request);
       return cb(result.get());
     }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(const NewOrderRequest& request) noexcept
-        -> AsyncNewOrderRequest {
+        -> AsyncNewOrderResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -6,7 +6,6 @@ using AsyncNewOrderResponse = std::future<NewOrderResponse>;
 namespace Bitwyre::Rest::Private {
 
   struct NewOrder {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders";
     }

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(const NewOrderRequest& request) noexcept
-        -> AsyncNewOrderRequest {
+        -> NewOrderRequest {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncNewOrderRequest = std::future<NewOrderRequest>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -3,11 +3,13 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncNewOrderResponse = std::future<NewOrderResponse>;
-using Callback = std::function<void(const NewOrderResponse&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct NewOrder {
+
+    using Callback = std::function<void(const NewOrderResponse&)>;
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders";
     }

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders";
     }
 
+    using Callback = std::function<void(const NewOrderResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto postAsync(Callback cb, const NewOrderRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(const NewOrderRequest& request) noexcept
         -> AsyncNewOrderRequest {

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(Callback cb, const NewOrderRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), NewOrderResponse>);
       auto result = postAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncNewOrderResponse = std::future<NewOrderResponse>;
+using Callback = std::function<void(const NewOrderResponse&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct NewOrder {
@@ -10,7 +12,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders";
     }
 
-    using Callback = std::function<void(const NewOrderResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(Callback cb, const NewOrderRequest& request) noexcept -> void {
       auto result = postAsync(request);

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Types::Private;
 using AsyncNewOrderRequest = std::future<NewOrderRequest>;
 namespace Bitwyre::Rest::Private {
@@ -13,7 +12,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(const NewOrderRequest& request) noexcept
-        -> NewOrderRequest {
+        -> AsyncNewOrderRequest {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OpenOrdersRequest& request) noexcept
-        -> Response {
+        -> AsyncResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/open";
     }
 
+    using Callback = std::function<void(const Response&)>;
+    template <typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const OpenOrdersRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OpenOrdersRequest& request) noexcept
         -> AsyncResponse {

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const OpenOrdersRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), Response>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OpenOrdersRequest& request) noexcept
-        -> AsyncResponse {
+        -> Response {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -17,7 +17,7 @@ namespace Bitwyre::Rest::Private {
       auto result = getAsync(request);
       return cb(result.get());
     }
-
+    
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OpenOrdersRequest& request) noexcept
         -> AsyncResponse {

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
-using Callback = std::function<void(const Response&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct OpenOrders {
+
+    using Callback = std::function<void(const Response&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders/open";

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
+using Callback = std::function<void(const Response&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct OpenOrders {
@@ -11,7 +13,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/open";
     }
 
-    using Callback = std::function<void(const Response&)>;
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const OpenOrdersRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -3,11 +3,13 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncOrderInfoResponse = std::future<OrderInfoResponse>;
-using Callback = std::function<void(const OrderInfoResponse&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct OrderInfo {
+
+    using Callback = std::function<void(const OrderInfoResponse&)>;
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders/info";
     }

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Types::Private;
 using AsyncOrderInfoResponse = std::future<OrderInfoResponse>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OrderInfoRequest& request) noexcept
-        -> AsyncOrderInfoResponse {
+        -> OrderInfoResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const OrderInfoRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), OrderInfoResponse>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OrderInfoRequest& request) noexcept
-        -> OrderInfoResponse {
+        -> AsyncOrderInfoResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncOrderInfoResponse = std::future<OrderInfoResponse>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -6,7 +6,6 @@ using AsyncOrderInfoResponse = std::future<OrderInfoResponse>;
 namespace Bitwyre::Rest::Private {
 
   struct OrderInfo {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/orders/info";
     }

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/info";
     }
 
+    using Callback = std::function<void(const OrderInfoResponse&)>;
+    template <typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const OrderInfoRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OrderInfoRequest& request) noexcept
         -> AsyncOrderInfoResponse {

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncOrderInfoResponse = std::future<OrderInfoResponse>;
+using Callback = std::function<void(const OrderInfoResponse&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct OrderInfo {
@@ -10,7 +12,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/orders/info";
     }
 
-    using Callback = std::function<void(const OrderInfoResponse&)>;
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const OrderInfoRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -3,11 +3,13 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
-using Callback = std::function<void(const Response&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct TradesHistory {
+
+    using Callback = std::function<void(const Response&)>;
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/trades";
     }

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TradesHistoryRequest& request) noexcept
-        -> Response {
+        -> AsyncResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -1,6 +1,6 @@
 #pragma once
-
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "../../details/Types.hpp"
+
 #include "../../details/Dispatcher.hpp"
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/trades";
     }
 
+    using Callback = std::function<void(const Response&)>;
+    template <typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const TradesHistoryRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TradesHistoryRequest& request) noexcept
         -> AsyncResponse {

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -13,7 +13,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TradesHistoryRequest& request) noexcept
-        -> AsyncResponse {
+        -> Response {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
+using Callback = std::function<void(const Response&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct TradesHistory {
@@ -10,7 +12,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/trades";
     }
 
-    using Callback = std::function<void(const Response&)>;
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TradesHistoryRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TradesHistoryRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), Response>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "../../details/Dispatcher.hpp"
-
+#include "../../details/Types.hpp"
+#include<future>
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "../../details/Types.hpp"
-#include<future>
+#include "../../details/Dispatcher.hpp"
 using namespace Bitwyre::Types::Private;
 using AsyncResponse = std::future<Response>;
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -6,7 +6,6 @@ using AsyncResponse = std::future<Response>;
 namespace Bitwyre::Rest::Private {
 
   struct TradesHistory {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/trades";
     }

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Types::Private;

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncTransactionHistoryResponse = std::future<TransactionHistoryResponse>;
+using Callback = std::function<void(const TransactionHistoryResponse&)>;
+
 namespace Bitwyre::Rest::Private {
 
   struct TransactionHistory {
@@ -10,7 +12,6 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/transactions";
     }
 
-    using Callback = std::function<void(const TransactionHistoryResponse&)>;
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TransactionHistoryRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "../../details/Dispatcher.hpp"
-
+#include "../../details/Types.hpp"
+#include<future>
 using namespace Bitwyre::Types::Private;
 
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -3,11 +3,13 @@
 
 using namespace Bitwyre::Types::Private;
 using AsyncTransactionHistoryResponse = std::future<TransactionHistoryResponse>;
-using Callback = std::function<void(const TransactionHistoryResponse&)>;
 
 namespace Bitwyre::Rest::Private {
 
   struct TransactionHistory {
+
+    using Callback = std::function<void(const TransactionHistoryResponse&)>;
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/account/transactions";
     }

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -2,7 +2,7 @@
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Types::Private;
-
+using AsyncTransactionHistoryResponse = std::future<TransactionHistoryResponse>;
 namespace Bitwyre::Rest::Private {
 
   struct TransactionHistory {
@@ -19,15 +19,13 @@ namespace Bitwyre::Rest::Private {
     }
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(
-        const TransactionHistoryRequest& request) noexcept
+    [[nodiscard]] static auto getAsync(const TransactionHistoryRequest& request) noexcept
         -> TransactionHistoryResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto get(
-        const TransactionHistoryRequest& request) noexcept
+    [[nodiscard]] static auto get(const TransactionHistoryRequest& request) noexcept
         -> TransactionHistoryResponse {
       auto rawResponse = Dispatcher()(uri(), request);
       return processResponse(std::move(rawResponse));

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -6,7 +6,6 @@ using AsyncTransactionHistoryResponse = std::future<TransactionHistoryResponse>;
 namespace Bitwyre::Rest::Private {
 
   struct TransactionHistory {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/private/account/transactions";
     }

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "../../details/Types.hpp"
+
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Types::Private;

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -20,7 +20,7 @@ namespace Bitwyre::Rest::Private {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TransactionHistoryRequest& request) noexcept
-        -> TransactionHistoryResponse {
+        -> AsyncTransactionHistoryResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../../details/Types.hpp"
-#include<future>
+#include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Types::Private;
 
 namespace Bitwyre::Rest::Private {

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Private {
       return "/private/account/transactions";
     }
 
+    using Callback = std::function<void(const TransactionHistoryResponse&)>;
+    template <typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const TransactionHistoryRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(
         const TransactionHistoryRequest& request) noexcept

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Private {
 
     template <typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TransactionHistoryRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), TransactionHistoryResponse>);
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Announcements.hpp
+++ b/cpp/source/rest/public/Announcements.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <iostream>
 #include <utility>
 #include "../../details/Dispatcher.hpp"

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncAssetResponse = std::future<AssetResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncAssetResponse = std::future<AssetResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -10,6 +10,14 @@ namespace Bitwyre::Rest::Public {
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets";
     }
+
+    using Callback = std::function<void(const AssetResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      auto result = getAsync();
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncAssetResponse {
         return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -6,7 +6,6 @@ using AsyncAssetResponse = std::future<AssetResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Asset {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets";
     }

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -3,14 +3,16 @@
 
 using namespace Bitwyre::Details;
 using AsyncAssetResponse = std::future<AssetResponse>;
+using Callback = std::function<void(const AssetResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct Asset {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets";
     }
 
-    using Callback = std::function<void(const AssetResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
       auto result = getAsync();

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), AssetResponse> );
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncAssetResponse = std::future<AssetResponse>;
-using Callback = std::function<void(const AssetResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Asset {
+
+    using Callback = std::function<void(const AssetResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets";

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncContractRequest = std::future<ContractRequest>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -3,14 +3,16 @@
 
 using namespace Bitwyre::Details;
 using AsyncContractResponse = std::future<ContractResponse>;
+using Callback = std::function<void(const ContractResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct Contract {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/contract";
     }
 
-    using Callback = std::function<void(const ContractResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const ContractRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -6,7 +6,6 @@ using AsyncContractResponse = std::future<ContractResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Contract {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/contract";
     }

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -2,7 +2,7 @@
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Details;
-using AsyncContractRequest = std::future<ContractRequest>;
+using AsyncContractResponse = std::future<ContractResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Contract {
@@ -19,7 +19,7 @@ namespace Bitwyre::Rest::Public {
     }
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(const ContractRequest& request) noexcept ->  AsyncContractRequest {
+    [[nodiscard]] static auto getAsync(const ContractRequest& request) noexcept ->  AsyncContractResponse {
         return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncContractRequest = std::future<ContractRequest>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncContractResponse = std::future<ContractResponse>;
-using Callback = std::function<void(const ContractResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Contract {
+
+    using Callback = std::function<void(const ContractResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/contract";

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const ContractRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), ContractResponse> );
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/contract";
     }
 
+    using Callback = std::function<void(const ContractResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const ContractRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const ContractRequest& request) noexcept ->  AsyncContractRequest {
         return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -11,10 +11,17 @@ namespace Bitwyre::Rest::Public {
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/crypto";
     }
+    using Callback = std::function<void(const CryptoAssetResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      auto result = getAsync();
+      return cb(result.get());
+    }//
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> CryptoAssetResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});
+
     }
 
     template<typename Dispatcher = Dispatcher>

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -19,7 +19,7 @@ namespace Bitwyre::Rest::Public {
     }//
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync() noexcept -> CryptoAssetResponse {
+    [[nodiscard]] static auto getAsync() noexcept -> AsyncCrytoAssetResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});
 
     }

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncCrytoAssetResponse = std::future<CryptoAssetResponse>;
-using Callback = std::function<void(const CryptoAssetResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct CryptoAsset {
+
+    using Callback = std::function<void(const CryptoAssetResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/crypto";

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -7,7 +7,6 @@ using AsyncCrytoAssetResponse = std::future<CryptoAssetResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct CryptoAsset {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/crypto";
     }

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncCrytoAssetResponse = std::future<CryptoAssetResponse>;
 

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncCrytoAssetResponse = std::future<CryptoAssetResponse>;
 

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -3,19 +3,21 @@
 
 using namespace Bitwyre::Details;
 using AsyncCrytoAssetResponse = std::future<CryptoAssetResponse>;
+using Callback = std::function<void(const CryptoAssetResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct CryptoAsset {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/crypto";
     }
-    using Callback = std::function<void(const CryptoAssetResponse&)>;
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
       auto result = getAsync();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncCrytoAssetResponse {

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), CryptoAssetResponse> );
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncDepthResponse = std::future<DepthResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncDepthResponse = std::future<DepthResponse>;
-using Callback = std::function<void(const DepthResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Depth {
+
+    using Callback = std::function<void(const DepthResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/depth";

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/depth";
     }
 
+    using Callback = std::function<void(const DepthResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const DepthRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const DepthRequest& request) noexcept -> AsyncDepthResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -3,14 +3,16 @@
 
 using namespace Bitwyre::Details;
 using AsyncDepthResponse = std::future<DepthResponse>;
+using Callback = std::function<void(const DepthResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct Depth {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/depth";
     }
 
-    using Callback = std::function<void(const DepthResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const DepthRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const DepthRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), DepthResponse> );
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -6,7 +6,6 @@ using AsyncDepthResponse = std::future<DepthResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Depth {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/depth";
     }

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncDepthResponse = std::future<DepthResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), FiatAssetResponse> );
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncFiatAssetResponse = std::future<FiatAssetResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncFiatAssetResponse = std::future<FiatAssetResponse>;
-using Callback = std::function<void(const FiatAssetResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct FiatAsset {
+
+    using Callback = std::function<void(const FiatAssetResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/fiat";

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncFiatAssetResponse = std::future<FiatAssetResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -11,8 +11,15 @@ namespace Bitwyre::Rest::Public {
       return "/public/assets/fiat";
     }
 
+    using Callback = std::function<void(const FiatAssetResponse&)>;
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync() noexcept ->  FiatAssetResponse {
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      auto result = getAsync();
+      return cb(result.get());
+    }//
+
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync() noexcept ->  AsyncFiatAssetResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});
     }
 

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -6,7 +6,6 @@ using AsyncFiatAssetResponse = std::future<FiatAssetResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct FiatAsset {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/fiat";
     }

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -3,19 +3,21 @@
 
 using namespace Bitwyre::Details;
 using AsyncFiatAssetResponse = std::future<FiatAssetResponse>;
+using Callback = std::function<void(const FiatAssetResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct FiatAsset {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/assets/fiat";
     }
 
-    using Callback = std::function<void(const FiatAssetResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
       auto result = getAsync();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept ->  AsyncFiatAssetResponse {

--- a/cpp/source/rest/public/Instrument.hpp
+++ b/cpp/source/rest/public/Instrument.hpp
@@ -4,14 +4,16 @@
 using namespace Bitwyre::Details;
 using namespace Bitwyre::Types::Public;
 using AsyncInstrumentResponse = std::future<InstrumentResponse>;
+using Callback = std::function<void(const InstrumentResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Instrument {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/pairs";
     }
-    using Callback = std::function<void(const InstrumentResponse&)>;
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const InstrumentRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/public/Instrument.hpp
+++ b/cpp/source/rest/public/Instrument.hpp
@@ -17,6 +17,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const InstrumentRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), InstrumentResponse> );
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Instrument.hpp
+++ b/cpp/source/rest/public/Instrument.hpp
@@ -4,11 +4,12 @@
 using namespace Bitwyre::Details;
 using namespace Bitwyre::Types::Public;
 using AsyncInstrumentResponse = std::future<InstrumentResponse>;
-using Callback = std::function<void(const InstrumentResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Instrument {
+
+    using Callback = std::function<void(const InstrumentResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/pairs";

--- a/cpp/source/rest/public/Instrument.hpp
+++ b/cpp/source/rest/public/Instrument.hpp
@@ -8,7 +8,6 @@ using AsyncInstrumentResponse = std::future<InstrumentResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Instrument {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/pairs";
     }

--- a/cpp/source/rest/public/Instrument.hpp
+++ b/cpp/source/rest/public/Instrument.hpp
@@ -12,6 +12,12 @@ namespace Bitwyre::Rest::Public {
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/pairs";
     }
+    using Callback = std::function<void(const InstrumentResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const InstrumentRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const InstrumentRequest& request) noexcept -> AsyncInstrumentResponse {

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), MarketResponse> );
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncMarketResponse = std::future<MarketResponse>;
-using Callback = std::function<void(const MarketResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Market {
+
+    using Callback = std::function<void(const MarketResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/markets";

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -19,7 +19,7 @@ namespace Bitwyre::Rest::Public {
     }//
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync() noexcept ->  MarketResponse {
+    [[nodiscard]] static auto getAsync() noexcept ->  AsyncMarketResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});
     }
 

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/markets";
     }
 
+    using Callback = std::function<void(const MarketResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      auto result = getAsync();
+      return cb(result.get());
+    }//
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept ->  MarketResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -6,7 +6,6 @@ using AsyncMarketResponse = std::future<MarketResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Market {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/markets";
     }

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -3,19 +3,21 @@
 
 using namespace Bitwyre::Details;
 using AsyncMarketResponse = std::future<MarketResponse>;
+using Callback = std::function<void(const MarketResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct Market {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/markets";
     }
 
-    using Callback = std::function<void(const MarketResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
       auto result = getAsync();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept ->  AsyncMarketResponse {

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncOrderTypesResponse = std::future<OrderTypesResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/ordertypes";
     }
 
+    using Callback = std::function<void(const OrderTypesResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      auto result = getAsync();
+      return cb(result.get());
+    }//
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> OrderTypesResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), OrderTypesResponse> );
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -19,7 +19,7 @@ namespace Bitwyre::Rest::Public {
     }//
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync() noexcept -> OrderTypesResponse {
+    [[nodiscard]] static auto getAsync() noexcept -> AsyncOrderTypesResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});
     }
 

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -3,11 +3,13 @@
 
 using namespace Bitwyre::Details;
 using AsyncOrderTypesResponse = std::future<OrderTypesResponse>;
-using Callback = std::function<void(const OrderTypesResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct OrderTypes {
+
+    using Callback = std::function<void(const OrderTypesResponse&)>;
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/ordertypes";
     }

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncOrderTypesResponse = std::future<OrderTypesResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -3,6 +3,8 @@
 
 using namespace Bitwyre::Details;
 using AsyncOrderTypesResponse = std::future<OrderTypesResponse>;
+using Callback = std::function<void(const OrderTypesResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct OrderTypes {
@@ -10,12 +12,11 @@ namespace Bitwyre::Rest::Public {
       return "/public/ordertypes";
     }
 
-    using Callback = std::function<void(const OrderTypesResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
       auto result = getAsync();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncOrderTypesResponse {

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -6,7 +6,6 @@ using AsyncOrderTypesResponse = std::future<OrderTypesResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct OrderTypes {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/ordertypes";
     }

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 using AsyncProductRequest = std::future<ProductResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncProductResponse = std::future<ProductResponse>;
-using Callback = std::function<void(const ProductResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Product {
+
+    using Callback = std::function<void(const ProductResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/products";

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -6,7 +6,6 @@ using AsyncProductResponse = std::future<ProductResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Product {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/products";
     }

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncProductRequest = std::future<ProductResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -2,7 +2,7 @@
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Details;
-using AsyncProductRequest = std::future<ProductResponse>;
+using AsyncProductResponse = std::future<ProductResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Product {
@@ -19,7 +19,7 @@ namespace Bitwyre::Rest::Public {
     }//
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync() noexcept -> ProductResponse {
+    [[nodiscard]] static auto getAsync() noexcept -> AsyncProductResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});
     }
 

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -3,19 +3,21 @@
 
 using namespace Bitwyre::Details;
 using AsyncProductResponse = std::future<ProductResponse>;
+using Callback = std::function<void(const ProductResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct Product {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/products";
     }
 
-    using Callback = std::function<void(const ProductResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
       auto result = getAsync();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncProductResponse {

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), ProductResponse> );
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/products";
     }
 
+    using Callback = std::function<void(const ProductResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      auto result = getAsync();
+      return cb(result.get());
+    }//
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> ProductResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -6,7 +6,6 @@ using AsyncSupportedLanguagesResponse = std::future<SupportedLanguagesResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct SupportedLanguages {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/languages";
     }
@@ -16,7 +15,7 @@ namespace Bitwyre::Rest::Public {
     [[nodiscard]] static auto getAsyncLanguage(Callback cb) noexcept -> void {
       auto result = getAsyncLanguage();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsyncLanguage() noexcept -> AsyncSupportedLanguagesResponse {

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
+#include <future>
 using namespace Bitwyre::Details;
 using AsyncSupportedLanguagesResponse = std::future<SupportedLanguagesResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsyncLanguage(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), SupportedLanguagesResponse> );
       auto result = getAsyncLanguage();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -11,6 +11,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/languages";
     }
 
+    using Callback = std::function<void(const SupportedLanguagesResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsyncLanguage(Callback cb) noexcept -> void {
+      auto result = getAsyncLanguage();
+      return cb(result.get());
+    }//
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsyncLanguage() noexcept -> AsyncSupportedLanguagesResponse {
         return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -3,14 +3,16 @@
 
 using namespace Bitwyre::Details;
 using AsyncSupportedLanguagesResponse = std::future<SupportedLanguagesResponse>;
+using Callback = std::function<void(const SupportedLanguagesResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct SupportedLanguages {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/languages";
     }
 
-    using Callback = std::function<void(const SupportedLanguagesResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsyncLanguage(Callback cb) noexcept -> void {
       auto result = getAsyncLanguage();

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncSupportedLanguagesResponse = std::future<SupportedLanguagesResponse>;
-using Callback = std::function<void(const SupportedLanguagesResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct SupportedLanguages {
+
+    using Callback = std::function<void(const SupportedLanguagesResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/languages";

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncSupportedLanguagesResponse = std::future<SupportedLanguagesResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-#include <future>
 using namespace Bitwyre::Details;
 using AsyncSupportedLanguagesResponse = std::future<SupportedLanguagesResponse>;
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -3,7 +3,7 @@
 
 using namespace Bitwyre::Details;
 using namespace Bitwyre::Types;
-using AsyncTickerRequest = std::future<TickerRequest>;
+using AsyncTickerResponse = std::future<TickerResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Ticker {
@@ -20,7 +20,7 @@ namespace Bitwyre::Rest::Public {
     }
 
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(const TickerRequest& request) noexcept -> AsyncTickerRequest {
+    [[nodiscard]] static auto getAsync(const TickerRequest& request) noexcept -> AsyncTickerResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -12,6 +12,13 @@ namespace Bitwyre::Rest::Public {
       return "/public/ticker";
     }
 
+    using Callback = std::function<void(const TickerResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const TickerRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TickerRequest& request) noexcept -> AsyncTickerRequest {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -7,7 +7,6 @@ using AsyncTickerResponse = std::future<TickerResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Ticker {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/ticker";
     }

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -4,11 +4,12 @@
 using namespace Bitwyre::Details;
 using namespace Bitwyre::Types;
 using AsyncTickerResponse = std::future<TickerResponse>;
-using Callback = std::function<void(const TickerResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Ticker {
+
+    using Callback = std::function<void(const TickerResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/ticker";

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -17,6 +17,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TickerRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), TickerResponse> );
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -4,14 +4,16 @@
 using namespace Bitwyre::Details;
 using namespace Bitwyre::Types;
 using AsyncTickerResponse = std::future<TickerResponse>;
+using Callback = std::function<void(const TickerResponse&)>;
+
 namespace Bitwyre::Rest::Public {
 
   struct Ticker {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/ticker";
     }
 
-    using Callback = std::function<void(const TickerResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TickerRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
+#include <future>
 using namespace Bitwyre::Details;
 using AsyncTimeResponse = std::future<TimeResponse>;
 

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -15,8 +15,10 @@ namespace Bitwyre::Rest::Public {
 
     using Callback = std::function<void(const TimeResponse&)>;
     template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
-      return std::async(std::launch::async, [=](){return cb(get<Dispatcher>());});
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      //return std::async(std::launch::async, [&](){return cb(get<Dispatcher>());});
+      auto result = getAsync();
+      return cb(result.get());
     }//
 
     template<typename Dispatcher = Dispatcher>

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 using AsyncTimeResponse = std::future<TimeResponse>;
 

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -3,12 +3,14 @@
 
 using namespace Bitwyre::Details;
 using AsyncTimeResponse = std::future<TimeResponse>;
-using Callback = std::function<void(const TimeResponse&)>;
 
 namespace Bitwyre::Rest::Public {
   using TimeT = std::chrono::nanoseconds;
 
   struct Time {
+
+    using Callback = std::function<void(const TimeResponse&)>;
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/time";
     }

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -17,9 +17,15 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), TimeResponse> );
       auto result = getAsync();
       return cb(result.get());
     }
+//    template<class Callback, typename Dispatcher = Dispatcher>
+//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
+//      static_assert( std::is_nothrow_invocable_v<decltype(cb), TimeResponse> );
+//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
+//    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncTimeResponse {

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -16,7 +16,7 @@ namespace Bitwyre::Rest::Public {
     using Callback = std::function<void(const TimeResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
-      return std::async(std::launch::async, [](Callback cb){return cb(get<Dispatcher>());}, std::move(cb));
+      return std::async(std::launch::async, [&cb](/*Callback cb*/){return cb(get<Dispatcher>());}/*, std::move(cb)*/);
     }
 
     template<typename Dispatcher = Dispatcher>

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -13,6 +13,11 @@ namespace Bitwyre::Rest::Public {
       return "/public/time";
     }
 
+    template<class Callback, typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getCallback(Callback cb) noexcept -> AsyncTimeResponse {
+      return std::async(std::launch::async, [](Callback cb){return cb(get<Dispatcher>());}, std::move(cb));
+    }
+
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncTimeResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -8,7 +8,6 @@ namespace Bitwyre::Rest::Public {
   using TimeT = std::chrono::nanoseconds;
 
   struct Time {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/time";
     }
@@ -19,7 +18,7 @@ namespace Bitwyre::Rest::Public {
       //return std::async(std::launch::async, [&](){return cb(get<Dispatcher>());});
       auto result = getAsync();
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncTimeResponse {

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -16,8 +16,8 @@ namespace Bitwyre::Rest::Public {
     using Callback = std::function<void(const TimeResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
-      return std::async(std::launch::async, [&cb](/*Callback cb*/){return cb(get<Dispatcher>());}/*, std::move(cb)*/);
-    }
+      return std::async(std::launch::async, [=](/*Callback cb*/){return cb(get<Dispatcher>());}/*, std::move(cb)*/);
+    }//
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncTimeResponse {

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-#include <future>
 using namespace Bitwyre::Details;
 using AsyncTimeResponse = std::future<TimeResponse>;
 

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -13,8 +13,9 @@ namespace Bitwyre::Rest::Public {
       return "/public/time";
     }
 
-    template<class Callback, typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getCallback(Callback cb) noexcept -> AsyncTimeResponse {
+    using Callback = std::function<void(const TimeResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
       return std::async(std::launch::async, [](Callback cb){return cb(get<Dispatcher>());}, std::move(cb));
     }
 

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -16,7 +16,7 @@ namespace Bitwyre::Rest::Public {
     using Callback = std::function<void(const TimeResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
-      return std::async(std::launch::async, [=](/*Callback cb*/){return cb(get<Dispatcher>());}/*, std::move(cb)*/);
+      return std::async(std::launch::async, [=](){return cb(get<Dispatcher>());});
     }//
 
     template<typename Dispatcher = Dispatcher>

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -3,6 +3,7 @@
 
 using namespace Bitwyre::Details;
 using AsyncTimeResponse = std::future<TimeResponse>;
+using Callback = std::function<void(const TimeResponse&)>;
 
 namespace Bitwyre::Rest::Public {
   using TimeT = std::chrono::nanoseconds;
@@ -12,10 +13,8 @@ namespace Bitwyre::Rest::Public {
       return "/public/time";
     }
 
-    using Callback = std::function<void(const TimeResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
-      //return std::async(std::launch::async, [&](){return cb(get<Dispatcher>());});
       auto result = getAsync();
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -7,7 +7,6 @@ using AsyncTradesResponse = std::future<TradesResponse>;
 namespace Bitwyre::Rest::Public {
 
   struct Trades {
-
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/trades";
     }
@@ -17,7 +16,7 @@ namespace Bitwyre::Rest::Public {
     [[nodiscard]] static auto getAsync(Callback cb, const TradesRequest& request) noexcept -> void {
       auto result = getAsync(request);
       return cb(result.get());
-    }//
+    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TradesRequest& request) noexcept -> AsyncTradesResponse {

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -2,6 +2,7 @@
 #include "../../details/Dispatcher.hpp"
 
 using namespace Bitwyre::Details;
+using AsyncTradesResponse = std::future<TradesResponse>;
 
 namespace Bitwyre::Rest::Public {
 
@@ -9,6 +10,18 @@ namespace Bitwyre::Rest::Public {
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/trades";
+    }
+
+    using Callback = std::function<void(const TradesResponse&)>;
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(Callback cb, const TradesRequest& request) noexcept -> void {
+      auto result = getAsync(request);
+      return cb(result.get());
+    }//
+
+    template<typename Dispatcher = Dispatcher>
+    [[nodiscard]] static auto getAsync(const TradesRequest& request) noexcept -> AsyncTradesResponse {
+      return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
     }
 
     template<typename Dispatcher = Dispatcher>

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
-
 using namespace Bitwyre::Details;
 
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -16,6 +16,7 @@ namespace Bitwyre::Rest::Public {
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TradesRequest& request) noexcept -> void {
+      static_assert( std::is_nothrow_invocable_v<decltype(cb), TradesResponse> );
       auto result = getAsync(request);
       return cb(result.get());
     }

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -3,15 +3,16 @@
 
 using namespace Bitwyre::Details;
 using AsyncTradesResponse = std::future<TradesResponse>;
+using Callback = std::function<void(const TradesResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Trades {
+
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/trades";
     }
 
-    using Callback = std::function<void(const TradesResponse&)>;
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(Callback cb, const TradesRequest& request) noexcept -> void {
       auto result = getAsync(request);

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -3,11 +3,12 @@
 
 using namespace Bitwyre::Details;
 using AsyncTradesResponse = std::future<TradesResponse>;
-using Callback = std::function<void(const TradesResponse&)>;
 
 namespace Bitwyre::Rest::Public {
 
   struct Trades {
+
+    using Callback = std::function<void(const TradesResponse&)>;
 
     [[nodiscard]] static auto uri() noexcept -> std::string {
       return "/public/trades";

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../details/Dispatcher.hpp"
+
 using namespace Bitwyre::Details;
 
 namespace Bitwyre::Rest::Public {

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -2,6 +2,7 @@
 #include "details/Types.hpp"
 #include "nlohmann/json.hpp"
 #include "gmock/gmock.h"
+#include <future>
 
 using ::testing::AtLeast;
 using json = nlohmann::json;
@@ -11,6 +12,7 @@ using Callback = std::function<void(const TimeResponse&)>;
 
 class MockAsyncDispatcher {
 public:
+    //MOCK_METHOD(std::future<void>, getAsync, (Callback cb));
     MOCK_METHOD(void, getAsync, (Callback cb));
     MOCK_METHOD(json, getAsync, ());
     MOCK_METHOD(json, getAsync, (DepthRequest request));

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -7,6 +7,7 @@ using ::testing::AtLeast;
 using json = nlohmann::json;
 using namespace Bitwyre::Types::Public;
 using namespace Bitwyre::Types::Private;
+using Callback = std::function<void(const TimeResponse&)>;
 
 class MockAsyncDispatcher {
 public:
@@ -25,28 +26,6 @@ public:
     MOCK_METHOD(json, getAsync, (OrderInfoRequest request));
     MOCK_METHOD(json, getAsync, (TradesHistoryRequest request));
     MOCK_METHOD(json, getAsync, (TransactionHistoryRequest request));
-
-//    MOCK_METHOD(json, getCallback, (Callback cb));
-//  //  template<class Callback, typename Dispatcher = Dispatcher>
-//    template<typename Callback>
-//    auto GetValue(Callback& call);
-//    template<>
-//    auto GetValue(json& value){
-//      getCallback(value);
-//    }
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
-//      return std::async(std::launch::async, [](Callback cb){return cb(get<Dispatcher>());}, std::move(cb));
-//    }
-
-//    template<typename ValueType>
-//    void GetValue(ValueType& value)
-//
-//    template <typename ValueType>
-//    void getValue(ValueType& value);
-//
-//    template<>
-//    void getValue(Callback cb) {
-//      getAsync(cb);
-//    }
+    MOCK_METHOD(json, getAsync, (Callback cb));
 
 };

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -11,7 +11,7 @@ using Callback = std::function<void(const TimeResponse&)>;
 
 class MockAsyncDispatcher {
 public:
-    MOCK_METHOD(json, getAsync, (Callback cb));
+    MOCK_METHOD(TimeResponse, getAsync, (Callback cb));
     MOCK_METHOD(json, getAsync, ());
     MOCK_METHOD(json, getAsync, (DepthRequest request));
     MOCK_METHOD(json, getAsync, (InstrumentRequest request));

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -11,6 +11,7 @@ using Callback = std::function<void(const TimeResponse&)>;
 
 class MockAsyncDispatcher {
 public:
+    MOCK_METHOD(json, getAsync, (Callback cb));
     MOCK_METHOD(json, getAsync, ());
     MOCK_METHOD(json, getAsync, (DepthRequest request));
     MOCK_METHOD(json, getAsync, (InstrumentRequest request));
@@ -26,6 +27,5 @@ public:
     MOCK_METHOD(json, getAsync, (OrderInfoRequest request));
     MOCK_METHOD(json, getAsync, (TradesHistoryRequest request));
     MOCK_METHOD(json, getAsync, (TransactionHistoryRequest request));
-    MOCK_METHOD(json, getAsync, (Callback cb));
 
 };

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -11,7 +11,7 @@ using Callback = std::function<void(const TimeResponse&)>;
 
 class MockAsyncDispatcher {
 public:
-    MOCK_METHOD(TimeResponse, getAsync, (Callback cb));
+    MOCK_METHOD(void, getAsync, (Callback cb));
     MOCK_METHOD(json, getAsync, ());
     MOCK_METHOD(json, getAsync, (DepthRequest request));
     MOCK_METHOD(json, getAsync, (InstrumentRequest request));

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -26,4 +26,27 @@ public:
     MOCK_METHOD(json, getAsync, (TradesHistoryRequest request));
     MOCK_METHOD(json, getAsync, (TransactionHistoryRequest request));
 
+//    MOCK_METHOD(json, getCallback, (Callback cb));
+//  //  template<class Callback, typename Dispatcher = Dispatcher>
+//    template<typename Callback>
+//    auto GetValue(Callback& call);
+//    template<>
+//    auto GetValue(json& value){
+//      getCallback(value);
+//    }
+//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> AsyncTimeResponse {
+//      return std::async(std::launch::async, [](Callback cb){return cb(get<Dispatcher>());}, std::move(cb));
+//    }
+
+//    template<typename ValueType>
+//    void GetValue(ValueType& value)
+//
+//    template <typename ValueType>
+//    void getValue(ValueType& value);
+//
+//    template<>
+//    void getValue(Callback cb) {
+//      getAsync(cb);
+//    }
+
 };

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -17,4 +17,12 @@ public:
     MOCK_METHOD(json, getAsync, (TickerRequest request));
     MOCK_METHOD(json, getAsync, (TradesRequest request));
     MOCK_METHOD(json, getAsync, (AccountBalanceRequest request));
+    MOCK_METHOD(json, getAsync, (AccountStatementRequest request));
+    MOCK_METHOD(json, delAsync, (CancelOrderRequest request));
+    MOCK_METHOD(json, getAsync, (OpenOrdersRequest request));
+    MOCK_METHOD(json, getAsync, (ClosedOrdersRequest request));
+    MOCK_METHOD(json, postAsync, (NewOrderRequest request));
+    MOCK_METHOD(json, getAsync, (OrderInfoRequest request));
+    MOCK_METHOD(json, getAsync, (TradesHistoryRequest request));
+
 };

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -17,13 +17,4 @@ public:
     MOCK_METHOD(json, getAsync, (TickerRequest request));
     MOCK_METHOD(json, getAsync, (TradesRequest request));
     MOCK_METHOD(json, getAsync, (AccountBalanceRequest request));
-    MOCK_METHOD(json, getAsync, (AccountStatementRequest request));
-    MOCK_METHOD(json, delAsync, (CancelOrderRequest request));
-    MOCK_METHOD(json, getAsync, (OpenOrdersRequest request));
-    MOCK_METHOD(json, getAsync, (ClosedOrdersRequest request));
-    MOCK_METHOD(json, postAsync, (NewOrderRequest request));
-    MOCK_METHOD(json, getAsync, (OrderInfoRequest request));
-    MOCK_METHOD(json, getAsync, (TradesHistoryRequest request));
-    MOCK_METHOD(json, getAsync, (TransactionHistoryRequest request));
-
 };

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -24,5 +24,6 @@ public:
     MOCK_METHOD(json, postAsync, (NewOrderRequest request));
     MOCK_METHOD(json, getAsync, (OrderInfoRequest request));
     MOCK_METHOD(json, getAsync, (TradesHistoryRequest request));
+    MOCK_METHOD(json, getAsync, (TransactionHistoryRequest request));
 
 };

--- a/cpp/source/unittest/privateApi.test.cpp
+++ b/cpp/source/unittest/privateApi.test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Account balance", "[rest][private][accountbalance]") {
   REQUIRE(response.statusCode_ == 200);
 }
 
-TEST_CASE("AsyncAccount balance", "[rest][private][async][accountbalance]") {
+TEST_CASE("Async Account balance", "[rest][private][async][accountbalance]") {
 
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
@@ -539,7 +539,7 @@ TEST_CASE("Closed orders request", "[rest][private][closedorders]") {
 }
 
 
-TEST_CASE("Async Closed orders request", "[rest][private][async][closedorders]") {
+TEST_CASE("Closed orders async request", "[rest][private][async][closedorders]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({
@@ -626,6 +626,7 @@ TEST_CASE("Async Closed orders request", "[rest][private][async][closedorders]")
 
 TEST_CASE("Open orders request", "[rest][private][closedorders]") {
   MockDispatcher mockDispatcher;
+  MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({
     "statusCode": 200,
     "error": [],
@@ -706,92 +707,9 @@ TEST_CASE("Open orders request", "[rest][private][closedorders]") {
   REQUIRE(response.openOrders.at(0).first == "btc_usd_spot");
 }
 
-TEST_CASE("Async Open orders request", "[rest][private][async][openorders]") {
+TEST_CASE("Open orders async request", "[rest][private][async][openorders]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
-  auto apiRes = R"({
-    "statusCode": 200,
-    "error": [],
-    "result": {
-    "btc_usd_spot": [
-        {
-            "AvgPx": "0",
-            "LastLiquidityInd": "0",
-            "LastPx": "0",
-            "LastQty": "0",
-            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
-            "cancelondisconnect": 0,
-            "clorderid": "",
-            "cumqty": "0",
-            "execid": "",
-            "exectype": 1,
-            "expiry": 0,
-            "fill_price": "0",
-            "instrument": "btc_usd_spot",
-            "leavesqty": "1",
-            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
-            "orderqty": "1",
-            "ordrejreason": "",
-            "ordstatus": 1,
-            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc9",
-            "ordtype": 1,
-            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
-            "price": "10.0",
-            "side": 1,
-            "stoppx": "0",
-            "time_in_force": 0,
-            "timestamp": 123123132123,
-            "transacttime": 0,
-            "value": "100.0"
-        },
-        {
-            "AvgPx": "0",
-            "LastLiquidityInd": "0",
-            "LastPx": "0",
-            "LastQty": "0",
-            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
-            "cancelondisconnect": 0,
-            "clorderid": "",
-            "cumqty": "0",
-            "execid": "",
-            "exectype": 1,
-            "expiry": 0,
-            "fill_price": "0",
-            "instrument": "btc_usd_spot",
-            "leavesqty": "1",
-            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
-            "orderqty": "1",
-            "ordrejreason": "",
-            "ordstatus": 1,
-            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc1",
-            "ordtype": 1,
-            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
-            "price": "10.0",
-            "side": 1,
-            "stoppx": "0",
-            "time_in_force": 0,
-            "timestamp": 2345676543246,
-            "transacttime": 0,
-            "value": "100.0"
-        }
-    ]
-    } })"_json;
-
-  OpenOrdersRequest request{InstrumentT{"btc_usd_spot"}};
-
-  EXPECT_CALL(mockDispatcher, dispatch(_, An<OpenOrdersRequest>()))
-      .WillOnce(Return(apiRes));
-  EXPECT_CALL(asyncDispatcher, getAsync(An<OpenOrdersRequest>()))
-  .WillOnce(Return(mockDispatcher.dispatch(OpenOrders::uri(), request)));
-  auto asyncRawRes = asyncDispatcher.getAsync(request);
-  auto response = OpenOrders::processResponse(std::move(asyncRawRes));
-  REQUIRE(response.openOrders.size() == 1);
-  REQUIRE(response.openOrders.at(0).second.size() == 2);
-  REQUIRE(response.openOrders.at(0).first == "btc_usd_spot");
-}
-
-TEST_CASE("Order info", "[rest][private][orderinfo]") {
-  MockDispatcher mockDispatcher;
   auto apiRes = R"({
     "statusCode": 200,
     "error": [],
@@ -863,8 +781,95 @@ TEST_CASE("Order info", "[rest][private][orderinfo]") {
 
   EXPECT_CALL(mockDispatcher, dispatch(_, An<OrderInfoRequest>()))
       .WillOnce(Return(apiRes));
-  auto rawResponse = mockDispatcher.dispatch(OrderInfo::uri(), request);
-  auto response = OrderInfo::processResponse(std::move(rawResponse));
+  EXPECT_CALL(asyncDispatcher, getAsync(An<OpenOrdersRequest>()))
+  .WillOnce(Return(mockDispatcher.dispatch(OpenOrders::uri(), request)));
+  auto asyncRawRes = asyncDispatcher.getAsync(request);
+  auto response = OpenOrders::processResponse(std::move(asyncRawRes));
+  REQUIRE(response.openOrders.size() == 1);
+  REQUIRE(response.openOrders.at(0).second.size() == 2);
+  REQUIRE(response.openOrders.at(0).first == "btc_usd_spot");
+}
+
+
+TEST_CASE("Async Order info", "[rest][private][async][orderinfo]") {
+  MockDispatcher mockDispatcher;
+  MockAsyncDispatcher asyncDispatcher;
+  auto apiRes = R"({
+    "statusCode": 200,
+    "error": [],
+    "result": [
+        {
+            "AvgPx": "0",
+            "LastLiquidityInd": "0",
+            "LastPx": "0",
+            "LastQty": "0",
+            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
+            "cancelondisconnect": 0,
+            "clorderid": "",
+            "cumqty": "0",
+            "execid": "",
+            "exectype": 1,
+            "expiry": 0,
+            "fill_price": "0",
+            "instrument": "btc_usd_spot",
+            "leavesqty": "1",
+            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
+            "orderqty": "1",
+            "ordrejreason": "",
+            "ordstatus": 1,
+            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc9",
+            "ordtype": 1,
+            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
+            "price": "10.0",
+            "side": 1,
+            "stoppx": "0",
+            "time_in_force": 0,
+            "timestamp": 123123132123,
+            "transacttime": 0,
+            "value": "100.0"
+        },
+        {
+            "AvgPx": "0",
+            "LastLiquidityInd": "0",
+            "LastPx": "0",
+            "LastQty": "0",
+            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
+            "cancelondisconnect": 0,
+            "clorderid": "",
+            "cumqty": "0",
+            "execid": "",
+            "exectype": 1,
+            "expiry": 0,
+            "fill_price": "0",
+            "instrument": "btc_usd_spot",
+            "leavesqty": "1",
+            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
+            "orderqty": "1",
+            "ordrejreason": "",
+            "ordstatus": 1,
+            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc1",
+            "ordtype": 1,
+            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
+            "price": "10.0",
+            "side": 1,
+            "stoppx": "0",
+            "time_in_force": 0,
+            "timestamp": 2345676543246,
+            "transacttime": 0,
+            "value": "100.0"
+        }
+    ]
+})"_json;
+
+  OrderInfoRequest request{OrderIdT{"9be73240-c3e4-4d0d-a8d7-57d9a6d798e1"}};
+
+  EXPECT_CALL(mockDispatcher, dispatch(_, An<OrderInfoRequest>()))
+      .WillOnce(Return(apiRes));
+  EXPECT_CALL(asyncDispatcher, getAsync())
+     .WillOnce(Return(mockDispatcher.dispatch(OrderInfo::uri(), request)));
+
+  auto asyncRawRes = asyncDispatcher.getAsync();
+  auto response = OrderInfo::processResponse(std::move(asyncRawRes));
 
   REQUIRE(response.ordersInfo.size() == 2);
   REQUIRE(response.ordersInfo.at(0).instrument == "btc_usd_spot");
@@ -1008,7 +1013,7 @@ TEST_CASE("New Order ", "[rest][private][neworder]") {
   REQUIRE(response.instrument == "btc_usd_spot");
 }
 
-TEST_CASE("Async New Order", "[rest][private][async][neworder]") {
+TEST_CASE("New Order Async ", "[rest][private][async][neworder]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({

--- a/cpp/source/unittest/privateApi.test.cpp
+++ b/cpp/source/unittest/privateApi.test.cpp
@@ -1013,7 +1013,7 @@ TEST_CASE("New Order ", "[rest][private][neworder]") {
   REQUIRE(response.instrument == "btc_usd_spot");
 }
 
-TEST_CASE("New Order Async ", "[rest][private][async][neworder]") {
+TEST_CASE("Async New Order", "[rest][private][async][neworder]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({

--- a/cpp/source/unittest/privateApi.test.cpp
+++ b/cpp/source/unittest/privateApi.test.cpp
@@ -624,7 +624,7 @@ TEST_CASE("Async Closed orders request", "[rest][private][async][closedorders]")
   REQUIRE(response.closedOrders.at(0).first == "btc_usd_spot");
 }
 
-TEST_CASE("Open orders request", "[rest][private][closedorders]") {
+TEST_CASE("Open orders request", "[rest][private][openorders]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({
@@ -777,9 +777,10 @@ TEST_CASE("Async Open orders request", "[rest][private][async][openorders]") {
     ]
 })"_json;
 
-  OrderInfoRequest request{OrderIdT{"9be73240-c3e4-4d0d-a8d7-57d9a6d798e1"}};
+ // OrderInfoRequest request{OrderIdT{"9be73240-c3e4-4d0d-a8d7-57d9a6d798e1"}};
+  OpenOrdersRequest request{InstrumentT{"btc_usd_spot"}};
 
-  EXPECT_CALL(mockDispatcher, dispatch(_, An<OrderInfoRequest>()))
+  EXPECT_CALL(mockDispatcher, dispatch(_, An<OpenOrdersRequest>()))
       .WillOnce(Return(apiRes));
   EXPECT_CALL(asyncDispatcher, getAsync(An<OpenOrdersRequest>()))
   .WillOnce(Return(mockDispatcher.dispatch(OpenOrders::uri(), request)));
@@ -790,6 +791,85 @@ TEST_CASE("Async Open orders request", "[rest][private][async][openorders]") {
   REQUIRE(response.openOrders.at(0).first == "btc_usd_spot");
 }
 
+TEST_CASE("Order info", "[rest][private][orderinfo]") {
+  MockDispatcher mockDispatcher;
+  auto apiRes = R"({
+    "statusCode": 200,
+    "error": [],
+    "result": [
+        {
+            "AvgPx": "0",
+            "LastLiquidityInd": "0",
+            "LastPx": "0",
+            "LastQty": "0",
+            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
+            "cancelondisconnect": 0,
+            "clorderid": "",
+            "cumqty": "0",
+            "execid": "",
+            "exectype": 1,
+            "expiry": 0,
+            "fill_price": "0",
+            "instrument": "btc_usd_spot",
+            "leavesqty": "1",
+            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
+            "orderqty": "1",
+            "ordrejreason": "",
+            "ordstatus": 1,
+            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc9",
+            "ordtype": 1,
+            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
+            "price": "10.0",
+            "side": 1,
+            "stoppx": "0",
+            "time_in_force": 0,
+            "timestamp": 123123132123,
+            "transacttime": 0,
+            "value": "100.0"
+        },
+        {
+            "AvgPx": "0",
+            "LastLiquidityInd": "0",
+            "LastPx": "0",
+            "LastQty": "0",
+            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
+            "cancelondisconnect": 0,
+            "clorderid": "",
+            "cumqty": "0",
+            "execid": "",
+            "exectype": 1,
+            "expiry": 0,
+            "fill_price": "0",
+            "instrument": "btc_usd_spot",
+            "leavesqty": "1",
+            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
+            "orderqty": "1",
+            "ordrejreason": "",
+            "ordstatus": 1,
+            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc1",
+            "ordtype": 1,
+            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
+            "price": "10.0",
+            "side": 1,
+            "stoppx": "0",
+            "time_in_force": 0,
+            "timestamp": 2345676543246,
+            "transacttime": 0,
+            "value": "100.0"
+        }
+    ]
+})"_json;
+
+  OrderInfoRequest request{OrderIdT{"9be73240-c3e4-4d0d-a8d7-57d9a6d798e1"}};
+
+  EXPECT_CALL(mockDispatcher, dispatch(_, An<OrderInfoRequest>()))
+      .WillOnce(Return(apiRes));
+  auto rawResponse = mockDispatcher.dispatch(OrderInfo::uri(), request);
+  auto response = OrderInfo::processResponse(std::move(rawResponse));
+
+  REQUIRE(response.ordersInfo.size() == 2);
+  REQUIRE(response.ordersInfo.at(0).instrument == "btc_usd_spot");
+}
 
 TEST_CASE("Async Order info", "[rest][private][async][orderinfo]") {
   MockDispatcher mockDispatcher;
@@ -876,89 +956,6 @@ TEST_CASE("Async Order info", "[rest][private][async][orderinfo]") {
 }
 
 
-TEST_CASE("Async Order info", "[rest][private][async][orderinfo]") {
-  MockDispatcher mockDispatcher;
-  MockAsyncDispatcher asyncDispatcher;
-  auto apiRes = R"({
-    "statusCode": 200,
-    "error": [],
-    "result": [
-        {
-            "AvgPx": "0",
-            "LastLiquidityInd": "0",
-            "LastPx": "0",
-            "LastQty": "0",
-            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
-            "cancelondisconnect": 0,
-            "clorderid": "",
-            "cumqty": "0",
-            "execid": "",
-            "exectype": 1,
-            "expiry": 0,
-            "fill_price": "0",
-            "instrument": "btc_usd_spot",
-            "leavesqty": "1",
-            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
-            "orderqty": "1",
-            "ordrejreason": "",
-            "ordstatus": 1,
-            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc9",
-            "ordtype": 1,
-            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc9",
-            "price": "10.0",
-            "side": 1,
-            "stoppx": "0",
-            "time_in_force": 0,
-            "timestamp": 123123132123,
-            "transacttime": 0,
-            "value": "100.0"
-        },
-        {
-            "AvgPx": "0",
-            "LastLiquidityInd": "0",
-            "LastPx": "0",
-            "LastQty": "0",
-            "account": "a9e3d010-3169-489d-9063-ced912b0fdc8",
-            "cancelondisconnect": 0,
-            "clorderid": "",
-            "cumqty": "0",
-            "execid": "",
-            "exectype": 1,
-            "expiry": 0,
-            "fill_price": "0",
-            "instrument": "btc_usd_spot",
-            "leavesqty": "1",
-            "orderid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
-            "orderqty": "1",
-            "ordrejreason": "",
-            "ordstatus": 1,
-            "ordstatusReqID": "a9e3d010-3169-489d-9063-ced912b0fdc1",
-            "ordtype": 1,
-            "origclid": "a9e3d010-3169-489d-9063-ced912b0fdc1",
-            "price": "10.0",
-            "side": 1,
-            "stoppx": "0",
-            "time_in_force": 0,
-            "timestamp": 2345676543246,
-            "transacttime": 0,
-            "value": "100.0"
-        }
-    ]
-})"_json;
-
-  OrderInfoRequest request{OrderIdT{"9be73240-c3e4-4d0d-a8d7-57d9a6d798e1"}};
-
-  EXPECT_CALL(mockDispatcher, dispatch(_, An<OrderInfoRequest>()))
-      .WillOnce(Return(apiRes));
-  EXPECT_CALL(asyncDispatcher, getAsync())
-     .WillOnce(Return(mockDispatcher.dispatch(OrderInfo::uri(), request)));
-
-  auto asyncRawRes = asyncDispatcher.getAsync();
-  auto response = OrderInfo::processResponse(std::move(asyncRawRes));
-
-  REQUIRE(response.ordersInfo.size() == 2);
-  REQUIRE(response.ordersInfo.at(0).instrument == "btc_usd_spot");
-}
 
 TEST_CASE("New Order ", "[rest][private][neworder]") {
   MockDispatcher mockDispatcher;

--- a/cpp/source/unittest/privateApi.test.cpp
+++ b/cpp/source/unittest/privateApi.test.cpp
@@ -539,7 +539,7 @@ TEST_CASE("Closed orders request", "[rest][private][closedorders]") {
 }
 
 
-TEST_CASE("Closed orders async request", "[rest][private][async][closedorders]") {
+TEST_CASE("Async Closed orders request", "[rest][private][async][closedorders]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({
@@ -707,7 +707,7 @@ TEST_CASE("Open orders request", "[rest][private][closedorders]") {
   REQUIRE(response.openOrders.at(0).first == "btc_usd_spot");
 }
 
-TEST_CASE("Open orders async request", "[rest][private][async][openorders]") {
+TEST_CASE("Async Open orders request", "[rest][private][async][openorders]") {
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   auto apiRes = R"({

--- a/cpp/source/unittest/privateApi.test.cpp
+++ b/cpp/source/unittest/privateApi.test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Account balance", "[rest][private][accountbalance]") {
   REQUIRE(response.statusCode_ == 200);
 }
 
-TEST_CASE("Async Account balance", "[rest][private][async][accountbalance]") {
+TEST_CASE("AsyncAccount balance", "[rest][private][async][accountbalance]") {
 
   MockDispatcher mockDispatcher;
   MockAsyncDispatcher asyncDispatcher;

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -64,20 +64,22 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
     REQUIRE(timeResponse.statusCode_ == 200);
 }
 
-TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") {
-  // Arrange
-  MockDispatcher mockDispatcher;
-  MockAsyncDispatcher asyncDispatcher;
-  json apiRes =
-      R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-  auto func = [](const TimeResponse& res){ };
-//  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
-//  EXPECT_CALL(asyncDispatcher,getAsync(An<std::function<void(const TimeResponse&)>>)).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
-//  auto asyncRawRes =
-//      asyncDispatcher.getAsync(func);
-//  auto timeResponse = Time::processResponse(std::move(asyncRawRes));
-
-}
+//TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") {
+//  // Arrange
+//  MockDispatcher mockDispatcher;
+//  MockAsyncDispatcher asyncDispatcher;
+//  json apiRes =
+//      R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
+//  bool callback_was_called = false;
+//  auto func = [&](const TimeResponse& res) noexcept -> void
+//  {
+//    callback_was_called = true;
+//    std::cout << "callback is invoked\n";
+//    REQUIRE(res.statusCode_ == 200);
+//  };
+//  Time::getAsync(func).get();
+//  REQUIRE(callback_was_called);
+//}
 
 TEST_CASE("Market request", "[rest][public][market]") {
   MockDispatcher mockDispatcher;

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -71,11 +71,13 @@ TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") 
   MockAsyncDispatcher asyncDispatcher;
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-
-  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
   auto func =[&](const TimeResponse&){return apiRes["result"]["unixtime"].get<long long int>();};
+
+  //EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
+ // EXPECT_CALL(asyncDispatcher,getAsync(func)).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
   auto asyncRawRes =
       asyncDispatcher.getAsync(func);
+  std::cout << "asyncRawRes " << asyncRawRes << "\n";
   auto timeResponse = Time::processResponse(std::move(asyncRawRes));
   REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
   REQUIRE(timeResponse.statusCode_ == 200);

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -1,5 +1,6 @@
 #include "MockDispatcher.hpp"
 #include "MockAsyncDispatcher.hpp"
+#include "MockAsyncCallbackDispather.hpp"
 #include "catch2/catch.hpp"
 #include "details/Types.hpp"
 #include "rest/public/Asset.hpp"
@@ -17,6 +18,8 @@
 #include "rest/public/Trades.hpp"
 #include <type_traits>
 #include <future>
+#include <chrono>
+#include <thread>
 
 using namespace Bitwyre::Rest::Public;
 using namespace Bitwyre::Types;
@@ -28,15 +31,15 @@ TEST_CASE("Time request", "[rest][public][time]") {
   MockDispatcher mockDispatcher;
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-
+  // when we send request to server, the server will return us REST
   EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>()))
       .WillOnce(Return(apiRes));
-
   auto rawResponse =
       mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{});
-  auto timeResponse = Time::processResponse(std::move(rawResponse));
+  // This return {"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} }
+  auto timeResponse = Time::processResponse(std::move(apiRes));
   // std::cout << timeResponse.unixtime.count() << "\n";
-  //std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
+  std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
   REQUIRE(timeResponse.unixtime ==
           static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
   REQUIRE(timeResponse.statusCode_ == 200);
@@ -61,6 +64,23 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
     REQUIRE(timeResponse.statusCode_ == 200);
 }
 
+TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") {
+  // Arrange
+  MockDispatcher mockDispatcher;
+  MockAsyncCallbackDispather asyncCallbackDispatcher;
+  json apiRes =
+      R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
+
+  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
+  EXPECT_CALL(asyncCallbackDispatcher,getAsyncCallback(An<CommonPublicRequest>())).WillOnce(Return(mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{})));
+
+//  auto asyncRawRes =
+//      asyncDispatcher.getAsync();
+//  auto timeResponse = Time::processResponse(std::move(asyncRawRes));
+//  REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
+//  REQUIRE(timeResponse.statusCode_ == 200);
+
+}
 
 TEST_CASE("Market request", "[rest][public][market]") {
   MockDispatcher mockDispatcher;

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -67,19 +67,12 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
 TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") {
   // Arrange
   MockDispatcher mockDispatcher;
- // MockAsyncCallbackDispatcher asyncCallbackDispatcher;
   MockAsyncDispatcher asyncDispatcher;
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-  Callback func =[=](const TimeResponse&){return apiRes["result"]["unixtime"].get<long long int>();};
+  auto func = [](const TimeResponse& res){ };
   EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
- EXPECT_CALL(asyncDispatcher,getAsync()).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
-  auto asyncRawRes =
-      asyncDispatcher.getAsync(func);
-  std::cout << "asyncRawRes " << asyncRawRes << "\n";
-  auto timeResponse = Time::processResponse(std::move(asyncRawRes));
-  REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
-  REQUIRE(timeResponse.statusCode_ == 200);
+  EXPECT_CALL(asyncDispatcher,getAsync(An<std::function<void(const TimeResponse&)>>)).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
 }
 
 TEST_CASE("Market request", "[rest][public][market]") {

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -71,8 +71,12 @@ TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") 
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
   auto func = [](const TimeResponse& res){ };
-  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
-  EXPECT_CALL(asyncDispatcher,getAsync(An<std::function<void(const TimeResponse&)>>)).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
+//  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
+//  EXPECT_CALL(asyncDispatcher,getAsync(An<std::function<void(const TimeResponse&)>>)).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
+//  auto asyncRawRes =
+//      asyncDispatcher.getAsync(func);
+//  auto timeResponse = Time::processResponse(std::move(asyncRawRes));
+
 }
 
 TEST_CASE("Market request", "[rest][public][market]") {

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -1,6 +1,6 @@
 #include "MockDispatcher.hpp"
 #include "MockAsyncDispatcher.hpp"
-#include "MockAsyncCallbackDispather.hpp"
+//#include "MockAsyncCallbackDispatcher.hpp"
 #include "catch2/catch.hpp"
 #include "details/Types.hpp"
 #include "rest/public/Asset.hpp"
@@ -67,18 +67,18 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
 TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") {
   // Arrange
   MockDispatcher mockDispatcher;
-  MockAsyncCallbackDispather asyncCallbackDispatcher;
+ // MockAsyncCallbackDispatcher asyncCallbackDispatcher;
+  MockAsyncDispatcher asyncDispatcher;
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
 
-  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
-  EXPECT_CALL(asyncCallbackDispatcher,getAsyncCallback(An<CommonPublicRequest>())).WillOnce(Return(mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{})));
-
-//  auto asyncRawRes =
-//      asyncDispatcher.getAsync();
-//  auto timeResponse = Time::processResponse(std::move(asyncRawRes));
-//  REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
-//  REQUIRE(timeResponse.statusCode_ == 200);
+ // EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
+  auto func =[&](const TimeResponse&){return apiRes["result"]["unixtime"].get<long long int>();};
+  auto asyncRawRes =
+      asyncDispatcher.getAsync(func);
+  auto timeResponse = Time::processResponse(std::move(asyncRawRes));
+  REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
+  REQUIRE(timeResponse.statusCode_ == 200);
 
 }
 

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -35,8 +35,13 @@ TEST_CASE("Time request", "[rest][public][time]") {
   auto rawResponse =
       mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{});
   auto timeResponse = Time::processResponse(std::move(rawResponse));
+<<<<<<< HEAD
   // std::cout << timeResponse.unixtime.count() << "\n";
   //std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
+=======
+  std::cout << timeResponse.unixtime.count() << "\n";
+  std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
+>>>>>>> d872085... getAsync<MockDispatcher> leads a SF
   REQUIRE(timeResponse.unixtime ==
           static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
   REQUIRE(timeResponse.statusCode_ == 200);
@@ -51,6 +56,8 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
 
     EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>()))
     .WillOnce(Return(apiRes));
+
+<<<<<<< HEAD
     EXPECT_CALL(asyncDispatcher,getAsync()).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
 
     auto asyncRawRes =
@@ -58,6 +65,18 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
     auto timeResponse = Time::processResponse(std::move(asyncRawRes));
     REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
     REQUIRE(timeResponse.statusCode_ == 200);
+=======
+    auto rawResponse =
+            mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{});
+    auto timeResponse = Time::processResponse(std::move(rawResponse));
+    Time time1;
+    auto future = time1.getAsync<MockDispatcher>();
+    auto response = future.get();
+ //   std::cout << response.unixtime << "\n";
+    REQUIRE(response.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
+    //REQUIRE( response.unixtime == apiRes["result"]["unixtime"].get<long long int>() );
+  //   REQUIRE(timeResponse.statusCode_ == 200);
+>>>>>>> d872085... getAsync<MockDispatcher> leads a SF
 }
 
 

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -35,13 +35,8 @@ TEST_CASE("Time request", "[rest][public][time]") {
   auto rawResponse =
       mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{});
   auto timeResponse = Time::processResponse(std::move(rawResponse));
-<<<<<<< HEAD
   // std::cout << timeResponse.unixtime.count() << "\n";
   //std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
-=======
-  std::cout << timeResponse.unixtime.count() << "\n";
-  std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
->>>>>>> d872085... getAsync<MockDispatcher> leads a SF
   REQUIRE(timeResponse.unixtime ==
           static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
   REQUIRE(timeResponse.statusCode_ == 200);
@@ -57,7 +52,6 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
     EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>()))
     .WillOnce(Return(apiRes));
 
-<<<<<<< HEAD
     EXPECT_CALL(asyncDispatcher,getAsync()).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
 
     auto asyncRawRes =
@@ -65,18 +59,6 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
     auto timeResponse = Time::processResponse(std::move(asyncRawRes));
     REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
     REQUIRE(timeResponse.statusCode_ == 200);
-=======
-    auto rawResponse =
-            mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{});
-    auto timeResponse = Time::processResponse(std::move(rawResponse));
-    Time time1;
-    auto future = time1.getAsync<MockDispatcher>();
-    auto response = future.get();
- //   std::cout << response.unixtime << "\n";
-    REQUIRE(response.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
-    //REQUIRE( response.unixtime == apiRes["result"]["unixtime"].get<long long int>() );
-  //   REQUIRE(timeResponse.statusCode_ == 200);
->>>>>>> d872085... getAsync<MockDispatcher> leads a SF
 }
 
 

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -72,7 +72,7 @@ TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") 
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
 
- // EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
+  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
   auto func =[&](const TimeResponse&){return apiRes["result"]["unixtime"].get<long long int>();};
   auto asyncRawRes =
       asyncDispatcher.getAsync(func);

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -71,17 +71,15 @@ TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") 
   MockAsyncDispatcher asyncDispatcher;
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-  auto func =[&](const TimeResponse&){return apiRes["result"]["unixtime"].get<long long int>();};
-
-  //EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
- // EXPECT_CALL(asyncDispatcher,getAsync(func)).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
+  Callback func =[=](const TimeResponse&){return apiRes["result"]["unixtime"].get<long long int>();};
+  EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>())).WillOnce(Return(apiRes));
+ EXPECT_CALL(asyncDispatcher,getAsync()).WillOnce(Return(mockDispatcher.dispatch(Time::uri(),CommonPublicRequest{})));
   auto asyncRawRes =
       asyncDispatcher.getAsync(func);
   std::cout << "asyncRawRes " << asyncRawRes << "\n";
   auto timeResponse = Time::processResponse(std::move(asyncRawRes));
   REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
   REQUIRE(timeResponse.statusCode_ == 200);
-
 }
 
 TEST_CASE("Market request", "[rest][public][market]") {


### PR DESCRIPTION
- add static_assert `std::is_nothrow_invocable_v` to all callback functions under public and private APIs.
- This acts as a precondition to all `getAsync(Callback) to be called.
- No further unit tests needed.