### PR TITLE
fix(async c++ api): clean up

### DIFF
--- a/cpp/source/rest/private/AccountBalance.hpp
+++ b/cpp/source/rest/private/AccountBalance.hpp
@@ -22,25 +22,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), AccountBalanceResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const AccountBalanceRequest& request) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), AccountBalanceResponse>);
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const AccountBalanceRequest& request) noexcept -> void {
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountBalanceRequest& request) noexcept
         -> AsyncAccountBalanceResponse {

--- a/cpp/source/rest/private/AccountStatement.hpp
+++ b/cpp/source/rest/private/AccountStatement.hpp
@@ -22,25 +22,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), AccountStatementResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const AccountStatementRequest& request) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), AccountStatementResponse>);
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const AccountStatementRequest& request) noexcept -> void {
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const AccountStatementRequest& request) noexcept
         -> AsyncAccountStatementResponse {

--- a/cpp/source/rest/private/CancelOrder.hpp
+++ b/cpp/source/rest/private/CancelOrder.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto delAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), ExecutionReport> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto delAsync(const CancelOrderRequest& request) noexcept
         -> AsyncExecutionReport {

--- a/cpp/source/rest/private/ClosedOrders.hpp
+++ b/cpp/source/rest/private/ClosedOrders.hpp
@@ -21,25 +21,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), ClosedOrdersResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrdersRequest& request) noexcept -> void{
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), ClosedOrdersResponse>);
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const ClosedOrdersRequest& request) noexcept -> void{
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const ClosedOrdersRequest& request) noexcept
         -> AsyncCloseOrdersResponse {

--- a/cpp/source/rest/private/NewOrder.hpp
+++ b/cpp/source/rest/private/NewOrder.hpp
@@ -21,25 +21,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), NewOrderResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto postAsync(Callback cb, const NewOrderRequest& request) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), NewOrderResponse>);
-      auto result = postAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto postAsync(Callback cb, const NewOrderRequest& request) noexcept -> void {
-      auto result = postAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto postAsync(const NewOrderRequest& request) noexcept
         -> AsyncNewOrderResponse {

--- a/cpp/source/rest/private/OpenOrders.hpp
+++ b/cpp/source/rest/private/OpenOrders.hpp
@@ -20,12 +20,6 @@ namespace Bitwyre::Rest::Private {
       auto result = getAsync(request);
       return cb(result.get());
     }
-
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), Response> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
     
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OpenOrdersRequest& request) noexcept

--- a/cpp/source/rest/private/OrderInfo.hpp
+++ b/cpp/source/rest/private/OrderInfo.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), OrderInfoResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const OrderInfoRequest& request) noexcept
         -> AsyncOrderInfoResponse {

--- a/cpp/source/rest/private/TradesHistory.hpp
+++ b/cpp/source/rest/private/TradesHistory.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), Response> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TradesHistoryRequest& request) noexcept
         -> AsyncResponse {

--- a/cpp/source/rest/private/TransactionHistory.hpp
+++ b/cpp/source/rest/private/TransactionHistory.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Private {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), TransactionHistoryResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TransactionHistoryRequest& request) noexcept
         -> TransactionHistoryResponse {

--- a/cpp/source/rest/public/Asset.hpp
+++ b/cpp/source/rest/public/Asset.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), AssetResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncAssetResponse {
         return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Contract.hpp
+++ b/cpp/source/rest/public/Contract.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), ContractResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const ContractRequest& request) noexcept ->  AsyncContractResponse {
         return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/CryptoAsset.hpp
+++ b/cpp/source/rest/public/CryptoAsset.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), CryptoAssetResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncCrytoAssetResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Depth.hpp
+++ b/cpp/source/rest/public/Depth.hpp
@@ -21,25 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), DepthResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const DepthRequest& request) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), DepthResponse> );
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const DepthRequest& request) noexcept -> void {
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const DepthRequest& request) noexcept -> AsyncDepthResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/FiatAsset.hpp
+++ b/cpp/source/rest/public/FiatAsset.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), FiatAssetResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept ->  AsyncFiatAssetResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Instrument.hpp
+++ b/cpp/source/rest/public/Instrument.hpp
@@ -22,25 +22,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), InstrumentResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const InstrumentRequest& request) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), InstrumentResponse> );
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const InstrumentRequest& request) noexcept -> void {
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const InstrumentRequest& request) noexcept -> AsyncInstrumentResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/Market.hpp
+++ b/cpp/source/rest/public/Market.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), MarketResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept ->  AsyncMarketResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/OrderTypes.hpp
+++ b/cpp/source/rest/public/OrderTypes.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), OrderTypesResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncOrderTypesResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Product.hpp
+++ b/cpp/source/rest/public/Product.hpp
@@ -21,12 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), ProductResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncProductResponse {
       return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/SupportedLanguages.hpp
+++ b/cpp/source/rest/public/SupportedLanguages.hpp
@@ -21,25 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), SupportedLanguagesResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsyncLanguage(Callback cb) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), SupportedLanguagesResponse> );
-      auto result = getAsyncLanguage();
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsyncLanguage(Callback cb) noexcept -> void {
-      auto result = getAsyncLanguage();
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsyncLanguage() noexcept -> AsyncSupportedLanguagesResponse {
         return std::async(std::launch::async, [](){return get<Dispatcher>();});

--- a/cpp/source/rest/public/Ticker.hpp
+++ b/cpp/source/rest/public/Ticker.hpp
@@ -22,12 +22,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), TickerResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TickerRequest& request) noexcept -> AsyncTickerResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/rest/public/Time.hpp
+++ b/cpp/source/rest/public/Time.hpp
@@ -21,29 +21,6 @@ namespace Bitwyre::Rest::Public {
       auto result = getAsync();
       return cb(result.get());
     }
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), TimeResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), TimeResponse> );
-      auto result = getAsync();
-      return cb(result.get());
-    }
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), TimeResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> void {
-      auto result = getAsync();
-      return cb(result.get());
-    }
 
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync() noexcept -> AsyncTimeResponse {

--- a/cpp/source/rest/public/Trades.hpp
+++ b/cpp/source/rest/public/Trades.hpp
@@ -21,35 +21,6 @@ namespace Bitwyre::Rest::Public {
       return cb(result.get());
     }
 
-//    template<class Callback, typename Dispatcher = Dispatcher>
-//    [[nodiscard]] static auto getAsync(Callback cb) noexcept -> std::future<void> {
-//      static_assert( std::is_nothrow_invocable_v<decltype(cb), TradesResponse> );
-//      return std::async(std::launch::async, [cb](){return cb(get<Dispatcher>());});
-//    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(const TradesRequest& request) noexcept -> AsyncTradesResponse {
-      return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const TradesRequest& request) noexcept -> void {
-      static_assert( std::is_nothrow_invocable_v<decltype(cb), TradesResponse> );
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(const TradesRequest& request) noexcept -> AsyncTradesResponse {
-      return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});
-    }
-
-    template<typename Dispatcher = Dispatcher>
-    [[nodiscard]] static auto getAsync(Callback cb, const TradesRequest& request) noexcept -> void {
-      auto result = getAsync(request);
-      return cb(result.get());
-    }
-
     template<typename Dispatcher = Dispatcher>
     [[nodiscard]] static auto getAsync(const TradesRequest& request) noexcept -> AsyncTradesResponse {
       return std::async(std::launch::async, [&request](){return get<Dispatcher>(request);});

--- a/cpp/source/unittest/MockAsyncDispatcher.hpp
+++ b/cpp/source/unittest/MockAsyncDispatcher.hpp
@@ -12,7 +12,6 @@ using Callback = std::function<void(const TimeResponse&)>;
 
 class MockAsyncDispatcher {
 public:
-    //MOCK_METHOD(std::future<void>, getAsync, (Callback cb));
     MOCK_METHOD(void, getAsync, (Callback cb));
     MOCK_METHOD(json, getAsync, ());
     MOCK_METHOD(json, getAsync, (DepthRequest request));

--- a/cpp/source/unittest/privateApi.test.cpp
+++ b/cpp/source/unittest/privateApi.test.cpp
@@ -99,10 +99,6 @@ TEST_CASE("Async Account balance", "[rest][private][async][accountbalance]") {
 
   auto asyncRawRes = asyncDispatcher.getAsync(accountBalanceRequest);
   auto response = AccountBalance::processResponse(std::move(asyncRawRes));
-//  auto rawResponse =
-//      mockDispatcher.dispatch(AccountBalance::uri(), accountBalanceRequest);
-//
-//  auto response = AccountBalance::processResponse(std::move(rawResponse));
 
   REQUIRE(response.balances.size() == 2);
   REQUIRE(response.balances.at(0).availableBalance == 10000);
@@ -777,7 +773,6 @@ TEST_CASE("Open orders async request", "[rest][private][async][openorders]") {
     ]
 })"_json;
 
- // OrderInfoRequest request{OrderIdT{"9be73240-c3e4-4d0d-a8d7-57d9a6d798e1"}};
   OpenOrdersRequest request{InstrumentT{"btc_usd_spot"}};
 
   EXPECT_CALL(mockDispatcher, dispatch(_, An<OpenOrdersRequest>()))

--- a/cpp/source/unittest/publicApi.test.cpp
+++ b/cpp/source/unittest/publicApi.test.cpp
@@ -31,14 +31,11 @@ TEST_CASE("Time request", "[rest][public][time]") {
   MockDispatcher mockDispatcher;
   json apiRes =
       R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-  // when we send request to server, the server will return us REST
   EXPECT_CALL(mockDispatcher, dispatch(_, An<CommonPublicRequest>()))
       .WillOnce(Return(apiRes));
   auto rawResponse =
       mockDispatcher.dispatch(Time::uri(), CommonPublicRequest{});
-  // This return {"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} }
   auto timeResponse = Time::processResponse(std::move(apiRes));
-  // std::cout << timeResponse.unixtime.count() << "\n";
   std::cout << ".unixtime = " << apiRes["result"]["unixtime"].get<long long int>() << "\n";
   REQUIRE(timeResponse.unixtime ==
           static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
@@ -46,7 +43,6 @@ TEST_CASE("Time request", "[rest][public][time]") {
 }
 
 TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
-    // Arrange
     MockDispatcher mockDispatcher;
     MockAsyncDispatcher asyncDispatcher;
     json apiRes =
@@ -63,25 +59,6 @@ TEST_CASE("AsyncTime request", "[rest][public][async][time]") {
     REQUIRE(timeResponse.unixtime ==  static_cast<TimeT>(apiRes["result"]["unixtime"].get<long long int>()));
     REQUIRE(timeResponse.statusCode_ == 200);
 }
-
-//TEST_CASE("AsyncCallbackTime request", "[rest][public][async][callback][time]") {
-//  // Arrange
-//  MockDispatcher mockDispatcher;
-//  MockAsyncDispatcher asyncDispatcher;
-//  json apiRes =
-//      R"({"statusCode": 200, "error": [], "result": {"unixtime": 1571744594571020435} })"_json;
-//  bool callback_was_called = false;
-//  auto func = [&](const TimeResponse& res) noexcept -> void
-//  {
-//    callback_was_called = true;
-//    std::cout << "callback is invoked\n";
-//    REQUIRE(res.statusCode_ == 200);
-//  };
-//  //Time::getAsync(func).get();
-//  Time::getAsync(func);
-//  std::cerr << "After calling Time::getAsync()\n";
-//  REQUIRE(callback_was_called);
-//}
 
 TEST_CASE("Market request", "[rest][public][market]") {
   MockDispatcher mockDispatcher;
@@ -916,11 +893,3 @@ TEST_CASE("Contract AsyncRequest", "[rest][public][async][contract]") {
   REQUIRE(response.instrument == "btcusdtx_usdt_200607F1000000");
   REQUIRE(response.statusCode_ == 200);
 }
-
-//TEST_CASE("Supported languages Request", "[rest][public][supportedlanguage]") {
-//  auto supportedLanguages = SupportedLanguages::get();
-//}
-
-//TEST_CASE("Supported languages AsyncRequest", "[rest][public][supportedlanguage]") {
-//  auto supportedLanguages = SupportedLanguages::getAsyncLanguage();
-//}


### PR DESCRIPTION
Tidy up 
* Remove all codes in comments
* Making sure all static assert replaced with `std::is_invocable_v`
* Remove comments codes in tests