### PR TITLE
refactor(rust-sdk): async APIs return JSON string.

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -9,134 +9,38 @@ async fn async_main() {
     let instrument = config::bitwyre_instrument("1");
     let instrument_contract = config::bitwyre_instrument("7");
 
-    match public::get_server_time_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_markets_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_products_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_assets_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_crypto_assets_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_fiat_assets_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_asset_pairs_async("crypto","spot","ID").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_ticker_async(instrument).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_trades_async("2", instrument).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_depth_async(instrument, "5").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_contract_async(instrument_contract).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_insider_profiles_async(None).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_insider_trades_async(None).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_announcements_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_order_types_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_languages_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_search_results_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_price_index_async(instrument, None, None, None, None).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_search_async("ID", None).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_matching_engine_order_lag_async(None).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match public::get_matching_engine_throughput_async(None).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_account_balance_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_account_statement_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_transaction_histories_async().await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_open_orders_async(instrument, 0, 0).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_closed_orders_async(instrument, 0, 0).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_order_info_async("3f128876-a082-4b18-8fd4-abbcc4aa7915").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::get_trade_history_async(instrument, 2, 0, 0).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::cancelling_open_order_per_instrument_async(instrument).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::cancelling_open_order_per_orderids_async(vec!["5033216a-dad5-4cb6-87d6-0084603be699", "3d19d8d1-c576-4109-8671-5e4115cf6e5e"], vec![-1, -1]).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::opening_new_order_async(instrument, 1, Some(35000.to_string()), 2, "0.0001").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
-    match private::opening_new_order_async(instrument, 1, Some("".to_string()), 1, "0.0001").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
-    }
+    println!("{:?}", public::get_server_time_async().await);
+    println!("{:?}", public::get_markets_async().await);
+    println!("{:?}", public::get_products_async().await);
+    println!("{:?}", public::get_assets_async().await);
+    println!("{:?}", public::get_crypto_assets_async().await);
+    println!("{:?}", public::get_fiat_assets_async().await);
+    println!("{:?}", public::get_asset_pairs_async("crypto","spot","ID").await);
+    println!("{:?}", public::get_ticker_async(instrument).await);
+    println!("{:?}", public::get_trades_async("2", instrument).await);
+    println!("{:?}", public::get_depth_async(instrument, "5").await);
+    println!("{:?}", public::get_contract_async(instrument_contract).await);
+    println!("{:?}", public::get_insider_profiles_async(None).await);
+    println!("{:?}", public::get_insider_trades_async(None).await);
+    println!("{:?}", public::get_announcements_async().await);
+    println!("{:?}", public::get_order_types_async().await);
+    println!("{:?}", public::get_languages_async().await);
+    println!("{:?}", public::get_search_results_async().await);
+    println!("{:?}", public::get_price_index_async(instrument, None, None, None, None).await);
+    println!("{:?}", public::get_search_async("ID", None).await);
+    println!("{:?}", public::get_matching_engine_order_lag_async(None).await);
+    println!("{:?}", public::get_matching_engine_throughput_async(None).await);
+    println!("{:?}", private::get_account_balance_async().await);
+    println!("{:?}", private::get_account_statement_async().await);
+    println!("{:?}", private::get_transaction_histories_async().await);
+    println!("{:?}", private::get_open_orders_async(instrument, 0, 0).await);
+    println!("{:?}", private::get_closed_orders_async(instrument, 0, 0).await);
+    println!("{:?}", private::get_order_info_async("3f128876-a082-4b18-8fd4-abbcc4aa7915").await);
+    println!("{:?}", private::get_trade_history_async(instrument, 2, 0, 0).await);
+    println!("{:?}", private::cancelling_open_order_per_instrument_async(instrument).await);
+    println!("{:?}", private::cancelling_open_order_per_orderids_async(vec!["5033216a-dad5-4cb6-87d6-0084603be699", "3d19d8d1-c576-4109-8671-5e4115cf6e5e"], vec![-1, -1]).await);
+    println!("{:?}", private::opening_new_order_async(instrument, 1, Some(35000.to_string()), 2, "0.0001").await);
+    println!("{:?}", private::opening_new_order_async(instrument, 1, Some("".to_string()), 1, "0.0001").await);
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -5,7 +5,16 @@ mod tests;
 use std::error::Error;
 use crate::public::config;
 
-async fn async_main() {
+async fn async_main(
+    product: &str, 
+    market: &str, 
+    country: &str, 
+    order_id: &str, 
+    order_ids: Vec<&str>, 
+    qtys: Vec<i32>, 
+    price: i32, 
+    orderqty: &str
+) {
     let instrument = config::bitwyre_instrument("1");
     let instrument_contract = config::bitwyre_instrument("7");
 
@@ -15,7 +24,7 @@ async fn async_main() {
     println!("{:?}", public::get_assets_async().await);
     println!("{:?}", public::get_crypto_assets_async().await);
     println!("{:?}", public::get_fiat_assets_async().await);
-    println!("{:?}", public::get_asset_pairs_async("crypto","spot","ID").await);
+    println!("{:?}", public::get_asset_pairs_async(product, market, country).await);
     println!("{:?}", public::get_ticker_async(instrument).await);
     println!("{:?}", public::get_trades_async("2", instrument).await);
     println!("{:?}", public::get_depth_async(instrument, "5").await);
@@ -27,7 +36,7 @@ async fn async_main() {
     println!("{:?}", public::get_languages_async().await);
     println!("{:?}", public::get_search_results_async().await);
     println!("{:?}", public::get_price_index_async(instrument, None, None, None, None).await);
-    println!("{:?}", public::get_search_async("ID", None).await);
+    println!("{:?}", public::get_search_async(country, None).await);
     println!("{:?}", public::get_matching_engine_order_lag_async(None).await);
     println!("{:?}", public::get_matching_engine_throughput_async(None).await);
     println!("{:?}", private::get_account_balance_async().await);
@@ -35,19 +44,28 @@ async fn async_main() {
     println!("{:?}", private::get_transaction_histories_async().await);
     println!("{:?}", private::get_open_orders_async(instrument, 0, 0).await);
     println!("{:?}", private::get_closed_orders_async(instrument, 0, 0).await);
-    println!("{:?}", private::get_order_info_async("3f128876-a082-4b18-8fd4-abbcc4aa7915").await);
+    println!("{:?}", private::get_order_info_async(order_id).await);
     println!("{:?}", private::get_trade_history_async(instrument, 2, 0, 0).await);
     println!("{:?}", private::cancelling_open_order_per_instrument_async(instrument).await);
-    println!("{:?}", private::cancelling_open_order_per_orderids_async(vec!["5033216a-dad5-4cb6-87d6-0084603be699", "3d19d8d1-c576-4109-8671-5e4115cf6e5e"], vec![-1, -1]).await);
-    println!("{:?}", private::opening_new_order_async(instrument, 1, Some(35000.to_string()), 2, "0.0001").await);
-    println!("{:?}", private::opening_new_order_async(instrument, 1, Some("".to_string()), 1, "0.0001").await);
+    println!("{:?}", private::cancelling_open_order_per_orderids_async(order_ids, qtys).await);
+    println!("{:?}", private::opening_new_order_async(instrument, 1, Some(price.to_string()), 2, orderqty).await);
+    println!("{:?}", private::opening_new_order_async(instrument, 1, Some(price.to_string()), 1, orderqty).await);
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let instrument = config::bitwyre_instrument("1");
     tokio::runtime::Runtime::new()
         .unwrap()
-        .block_on(async_main());
+        .block_on(async_main(
+            "crypto",
+            "spot",
+            "ID",
+            "3f128876-a082-4b18-8fd4-abbcc4aa7915",
+            vec!["5033216a-dad5-4cb6-87d6-0084603be699", "3d19d8d1-c576-4109-8671-5e4115cf6e5e"], 
+            vec![-1, -1],
+            35000,
+            "0.0001"
+        ));
 
     match public::get_server_time() {
         Err(e) => println!("{:?}", e),

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -322,15 +322,17 @@ pub fn opening_new_order(
 }
 
 use async_trait::async_trait;
+use reqwest::{Response, Error as ReqError};
 
 #[async_trait]
 trait RequestAsync {
-    async fn execute_async(&self, temp: &str, api_key: &str, signature: &str, flag: &str) -> Result<(), Box<dyn Error>>;
+    async fn execute_async(&self, temp: &str, api_key: &str, signature: &str, flag: &str) -> Result<Response, ReqError>;
+    async fn return_text_or_panic(&self, res: Response) -> String;
 }
 
 #[async_trait]
 impl RequestAsync for PrivateAPI {
-    async fn execute_async(&self, temp: &str, api_key: &str, signature: &str, flag: &str) -> Result<(), Box<dyn Error>> {
+    async fn execute_async(&self, temp: &str, api_key: &str, signature: &str, flag: &str) -> Result<Response, ReqError> {
         let mut headers = header::HeaderMap::new();
         headers.insert("API-Key", header::HeaderValue::from_str(&api_key).unwrap());
         headers.insert("API-Sign", header::HeaderValue::from_str(&signature).unwrap());
@@ -340,29 +342,25 @@ impl RequestAsync for PrivateAPI {
             .timeout(Duration::from_secs(config::timeout()))
             .build()?;
 
-        let res;
         if flag == "NewOrder" {
-            res = client.post(temp).send().await?;
+            return Ok(client.post(temp).send().await?);
         } else if flag == "CancelOrder" {
-            res = client.delete(temp).send().await?;
-        } else {
-            res = client.get(temp).send().await?;
+            return Ok(client.delete(temp).send().await?);
         }
 
+        Ok(client.get(temp).send().await?)
+    }
+    async fn return_text_or_panic(&self, res: Response) -> String {
         match res.status() {
-            reqwest::StatusCode::OK => {
-                println!("Status: {} -> {}", res.status(), "Success");
-                println!("{}", res.text().await?);
-            },
+            reqwest::StatusCode::OK => res.text().await.unwrap(),
             _ => {
                 panic!("{} -> {}", res.status(), "Error, please check again your request");
             },
-        };
-        Ok(())
+        }
     }
 }
 
-pub async fn get_account_balance_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_account_balance_async() -> Result<String, Box<dyn Error>> {
     let payload = "";
     let uri_path = config::get_private_api_endpoint(&"ACCOUNT_BALANCE");
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -371,14 +369,16 @@ pub async fn get_account_balance_async() -> Result<(), Box<dyn Error>> {
         config::get_private_api_endpoint(&"ACCOUNT_BALANCE"),
         &param
     );
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_account_statement_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_account_statement_async() -> Result<String, Box<dyn Error>> {
     let payload = "";
     let uri_path = config::get_private_api_endpoint(&"ACCOUNT_STATEMENT");
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -387,14 +387,17 @@ pub async fn get_account_statement_async() -> Result<(), Box<dyn Error>> {
         config::get_private_api_endpoint(&"ACCOUNT_STATEMENT"),
         &param
     );
+    
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_transaction_histories_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_transaction_histories_async() -> Result<String, Box<dyn Error>> {
     let payload = "";
     let uri_path = config::get_private_api_endpoint(&"TRANSACTION_HISTORIES");
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -403,14 +406,16 @@ pub async fn get_transaction_histories_async() -> Result<(), Box<dyn Error>> {
         config::get_private_api_endpoint(&"TRANSACTION_HISTORIES"),
         &param
     );
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_open_orders_async(instrument: &str, from_time: u128, to_time: u128) -> Result<(), Box<dyn Error>> {
+pub async fn get_open_orders_async(instrument: &str, from_time: u128, to_time: u128) -> Result<String, Box<dyn Error>> {
     let payload = ["{\"instrument\":", "\"", &instrument, "\"", ",\"from_time\":", &from_time.to_string(), ",\"to_time\":", &to_time.to_string(), "}"].concat();
     let uri_path = config::get_private_api_endpoint(&"OPEN_ORDERS");
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -419,14 +424,16 @@ pub async fn get_open_orders_async(instrument: &str, from_time: u128, to_time: u
         config::get_private_api_endpoint(&"OPEN_ORDERS"),
         &param
     );
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_closed_orders_async(instrument: &str, from_time: u128, to_time: u128) -> Result<(), Box<dyn Error>> {
+pub async fn get_closed_orders_async(instrument: &str, from_time: u128, to_time: u128) -> Result<String, Box<dyn Error>> {
     let payload = ["{\"instrument\":", "\"", &instrument, "\"", ",\"from_time\":", &from_time.to_string(), ",\"to_time\":", &to_time.to_string(), "}"].concat();
     let uri_path = config::get_private_api_endpoint(&"CLOSED_ORDERS");
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -435,14 +442,16 @@ pub async fn get_closed_orders_async(instrument: &str, from_time: u128, to_time:
         config::get_private_api_endpoint(&"CLOSED_ORDERS"),
         &param
     );
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_order_info_async(order_id: &str) -> Result<(), Box<dyn Error>> {
+pub async fn get_order_info_async(order_id: &str) -> Result<String, Box<dyn Error>> {
     let payload = "";
     let uri_path = [config::get_private_api_endpoint(&"ORDER_INFO"), "/", order_id].concat();
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -451,14 +460,16 @@ pub async fn get_order_info_async(order_id: &str) -> Result<(), Box<dyn Error>> 
         &uri_path,
         &param
     );
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_trade_history_async(instrument: &str, count: u8, from_time: u128, to_time: u128) -> Result<(), Box<dyn Error>> {
+pub async fn get_trade_history_async(instrument: &str, count: u8, from_time: u128, to_time: u128) -> Result<String, Box<dyn Error>> {
     let payload = ["{\"instrument\":", "\"", &instrument, "\"", ",\"count\":", &count.to_string(), ",\"from_time\":", &from_time.to_string(), ",\"to_time\":", &to_time.to_string(), "}"].concat();
     let uri_path = config::get_private_api_endpoint(&"TRADE_HISTORY");
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -467,14 +478,16 @@ pub async fn get_trade_history_async(instrument: &str, count: u8, from_time: u12
         config::get_private_api_endpoint(&"TRADE_HISTORY"),
         &param
     );
+
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn cancelling_open_order_per_instrument_async(instrument: &str) -> Result<(), Box<dyn Error>> {
+pub async fn cancelling_open_order_per_instrument_async(instrument: &str) -> Result<String, Box<dyn Error>> {
     let payload = "";
     let uri_path = [config::get_private_api_endpoint(&"CANCEL_ORDER"), "/instrument/", instrument].concat();
     let (param, api_key, signature) = URLBuilder.build_nonce_checksum_payload(&uri_path, &payload);
@@ -483,14 +496,16 @@ pub async fn cancelling_open_order_per_instrument_async(instrument: &str) -> Res
         &uri_path,
         &param
     );
+    
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "CancelOrder").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn cancelling_open_order_per_orderids_async(order_ids: Vec<&str>, qtys: Vec<i32>) -> Result<(), Box<dyn Error>> {
+pub async fn cancelling_open_order_per_orderids_async(order_ids: Vec<&str>, qtys: Vec<i32>) -> Result<String, Box<dyn Error>> {
     let temp = format!("{:?}", order_ids);
     let temp2 = format!("{:?}", qtys);
     if order_ids.len() != qtys.len() {
@@ -504,11 +519,13 @@ pub async fn cancelling_open_order_per_orderids_async(order_ids: Vec<&str>, qtys
         config::get_private_api_endpoint(&"CANCEL_ORDER"),
         &param
     );
+    
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "CancelOrder").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
 pub async fn opening_new_order_async(
@@ -517,7 +534,7 @@ pub async fn opening_new_order_async(
     mut price: Option<String>,
     ordtype: u8,
     orderqty: &str
-) -> Result<(), Box<dyn Error>> {
+) -> Result<String, Box<dyn Error>> {
     if ordtype == 1 {
         price = Some("0".to_string());
     }
@@ -533,9 +550,11 @@ pub async fn opening_new_order_async(
         config::get_private_api_endpoint(&"ORDER"),
         &param
     );
+    
     match PrivateAPI.execute_async(&temp, &api_key, &signature, "NewOrder").await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PrivateAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -296,7 +296,8 @@ pub fn opening_new_order(
     side: u8,
     mut price: Option<String>,
     ordtype: u8,
-    orderqty: &str) -> Result<(), Box<dyn Error>> {
+    orderqty: &str
+) -> Result<(), Box<dyn Error>> {
     if ordtype == 1 {
         price = Some("0".to_string());
     }

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -354,7 +354,7 @@ impl RequestAsync for PrivateAPI {
         match res.status() {
             reqwest::StatusCode::OK => res.text().await.unwrap(),
             _ => {
-                panic!("{} -> {}", res.status(), "Error, please check again your request");
+                panic!("{} -> {}", res.status(), res.text().await.unwrap());
             },
         }
     }

--- a/rust/src/public.rs
+++ b/rust/src/public.rs
@@ -194,108 +194,114 @@ pub fn get_announcements() -> Result<(), Box<dyn Error>> {
 }
 
 use async_trait::async_trait;
+use reqwest::{Response, Error as ReqError};
 
 #[async_trait]
 trait RequestAsync {
-    async fn execute_async(&self, temp: &str) -> Result<(), Box<dyn Error>>;
+    async fn execute_async(&self, temp: &str) -> Result<Response, ReqError>;
+    async fn return_text_or_panic(&self, res: Response) -> String;
 }
 
 #[async_trait]
 impl RequestAsync for PublicAPI {
-    async fn execute_async(&self, temp: &str) -> Result<(), Box<dyn Error>> {
-        let res = reqwest::get(temp).await?;
+    async fn execute_async(&self, temp: &str) -> Result<Response, ReqError> {
+        Ok(reqwest::get(temp).await?)
+    }
+    async fn return_text_or_panic(&self, res: Response) -> String {
         match res.status() {
-            reqwest::StatusCode::OK => {
-                println!("Status: {} -> {}", res.status(), "Success");
-                println!("{}", res.text().await?);
-            },
+            reqwest::StatusCode::OK => res.text().await.unwrap(),
             _ => {
-                panic!("{} -> {}", res.status(), "Error, please check again your request");
+                panic!("{} -> {}", res.status(), "Error, please check your request again");
             },
-        };
-        Ok(())
+        }
     }
 }
 
-pub async fn get_server_time_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_server_time_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"SERVERTIME"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_markets_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_markets_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"MARKETS"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_products_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_products_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"PRODUCTS"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_assets_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_assets_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"ASSETS"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_crypto_assets_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_crypto_assets_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"ASSETS_CRYPTO"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_fiat_assets_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_fiat_assets_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"ASSETS_FIAT"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_asset_pairs_async(market: &str, product: &str, country: &str) -> Result<(), Box<dyn Error>> {
+pub async fn get_asset_pairs_async(market: &str, product: &str, country: &str) -> Result<String, Box<dyn Error>> {
     let param = ["?market=", &market, "&product=", &product, "&country=", &country].concat();
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -303,13 +309,14 @@ pub async fn get_asset_pairs_async(market: &str, product: &str, country: &str) -
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_trades_async(trade_num: &str, instrument: &str) -> Result<(), Box<dyn Error>> {
+pub async fn get_trades_async(trade_num: &str, instrument: &str) -> Result<String, Box<dyn Error>> {
     let param = ["?trade_num=", &trade_num, "&instrument=", &instrument].concat();
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -317,13 +324,14 @@ pub async fn get_trades_async(trade_num: &str, instrument: &str) -> Result<(), B
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_depth_async(instrument: &str, depth_num: &str) -> Result<(), Box<dyn Error>> {
+pub async fn get_depth_async(instrument: &str, depth_num: &str) -> Result<String, Box<dyn Error>> {
     let param = ["?instrument=", &instrument, "&depth_num=", &depth_num].concat();
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -331,13 +339,14 @@ pub async fn get_depth_async(instrument: &str, depth_num: &str) -> Result<(), Bo
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_ticker_async(instrument: &str) -> Result<(), Box<dyn Error>> {
+pub async fn get_ticker_async(instrument: &str) -> Result<String, Box<dyn Error>> {
     let param = ["?instrument=", &instrument].concat();
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -345,13 +354,14 @@ pub async fn get_ticker_async(instrument: &str) -> Result<(), Box<dyn Error>> {
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_contract_async(instrument: &str) -> Result<(), Box<dyn Error>> {
+pub async fn get_contract_async(instrument: &str) -> Result<String, Box<dyn Error>> {
     let param = ["?instrument=", &instrument].concat();
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -359,13 +369,14 @@ pub async fn get_contract_async(instrument: &str) -> Result<(), Box<dyn Error>> 
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_insider_profiles_async(username: Option<&str>) -> Result<(), Box<dyn Error>> {
+pub async fn get_insider_profiles_async(username: Option<&str>) -> Result<String, Box<dyn Error>> {
     let param = URLBuilder.optional_string_param("username", username);
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -373,13 +384,14 @@ pub async fn get_insider_profiles_async(username: Option<&str>) -> Result<(), Bo
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_insider_trades_async(username: Option<&str>) -> Result<(), Box<dyn Error>> {
+pub async fn get_insider_trades_async(username: Option<&str>) -> Result<String, Box<dyn Error>> {
     let param = URLBuilder.optional_string_param("username", username);
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -387,65 +399,70 @@ pub async fn get_insider_trades_async(username: Option<&str>) -> Result<(), Box<
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_announcements_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_announcements_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"ANNOUNCEMENTS"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_order_types_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_order_types_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"ORDER_TYPES"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_languages_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_languages_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"LANGUAGES"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_search_results_async() -> Result<(), Box<dyn Error>> {
+pub async fn get_search_results_async() -> Result<String, Box<dyn Error>> {
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
         config::get_public_api_endpoint(&"SEARCH"),
         ""
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_price_index_async(instrument: &str, amount: Option<&i8>, to_time: Option<&i8>, from_time: Option<&i8>, ascending: Option<&bool>) -> Result<(), Box<dyn Error>> {
+pub async fn get_price_index_async(instrument: &str, amount: Option<&i8>, to_time: Option<&i8>, from_time: Option<&i8>, ascending: Option<&bool>) -> Result<String, Box<dyn Error>> {
     let mut param = ["?instrument=", &instrument].concat();
     param = URLBuilder.append_optional_integer_param(param, "amount", amount);
     param = URLBuilder.append_optional_integer_param(param, "to_time", to_time);
@@ -457,13 +474,14 @@ pub async fn get_price_index_async(instrument: &str, amount: Option<&i8>, to_tim
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_search_async(country: &str, instrument: Option<&str>) -> Result<(), Box<dyn Error>> {
+pub async fn get_search_async(country: &str, instrument: Option<&str>) -> Result<String, Box<dyn Error>> {
     let mut param = ["?country=", &country].concat();
     param = URLBuilder.append_optional_string_param(param, "instrument", instrument);
     let temp = URLBuilder.format (
@@ -472,13 +490,14 @@ pub async fn get_search_async(country: &str, instrument: Option<&str>) -> Result
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_matching_engine_order_lag_async(instrument: Option<&str>) -> Result<(), Box<dyn Error>> {
+pub async fn get_matching_engine_order_lag_async(instrument: Option<&str>) -> Result<String, Box<dyn Error>> {
     let param = URLBuilder.optional_string_param("instrument", instrument);
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -486,13 +505,14 @@ pub async fn get_matching_engine_order_lag_async(instrument: Option<&str>) -> Re
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }
 
-pub async fn get_matching_engine_throughput_async(instrument: Option<&str>) -> Result<(), Box<dyn Error>> {
+pub async fn get_matching_engine_throughput_async(instrument: Option<&str>) -> Result<String, Box<dyn Error>> {
     let param = URLBuilder.optional_string_param("instrument", instrument);
     let temp = URLBuilder.format (
         &config::url_api_bitwyre(),
@@ -500,8 +520,9 @@ pub async fn get_matching_engine_throughput_async(instrument: Option<&str>) -> R
         &param
     );
     match PublicAPI.execute_async(&temp).await {
-        Err(e) => println!("{:?}", e),
-        _ => ()
+        Ok(res) => Ok(
+            PublicAPI.return_text_or_panic(res).await
+        ),
+        Err(e) => Err(Box::new(e)),
     }
-    Ok(())
 }

--- a/rust/tests/private.rs
+++ b/rust/tests/private.rs
@@ -1,0 +1,138 @@
+#[cfg(test)]
+mod test {
+    use rust_sdk::{
+        private,
+        public::config
+    };
+    use serde::{Deserialize, Serialize};
+    
+    #[derive(Serialize, Deserialize)]
+    struct ResultString {
+        error: Vec<String>,
+    }
+    
+    #[tokio::test]
+    async fn get_account_balance_async_should_work() {
+        let data = private::get_account_balance_async().await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn get_account_statement_async_should_work() {
+        let data = private::get_account_statement_async().await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn get_transaction_histories_async_should_work() {
+        let data = private::get_transaction_histories_async().await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn get_open_orders_async_should_work() {
+        let instrument = config::bitwyre_instrument("1");
+        let data = private::get_open_orders_async(instrument, 0, 0).await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn get_closed_orders_async_should_work() {
+        let instrument = config::bitwyre_instrument("1");
+        let data = private::get_closed_orders_async(instrument, 0, 0).await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn get_order_info_async_should_work() {
+        let data = private::get_order_info_async("3f128876-a082-4b18-8fd4-abbcc4aa7915").await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn get_trade_history_async_should_work() {
+        let instrument = config::bitwyre_instrument("1");
+        let data = private::get_trade_history_async(instrument, 2, 0, 0).await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn cancelling_open_order_per_instrument_async_should_work() {
+        let instrument = config::bitwyre_instrument("1");
+        let data = private::cancelling_open_order_per_instrument_async(instrument).await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn cancelling_open_order_per_orderids_async_should_work() {
+        let data = private::cancelling_open_order_per_orderids_async(
+            vec!["5033216a-dad5-4cb6-87d6-0084603be699", "3d19d8d1-c576-4109-8671-5e4115cf6e5e"], vec![-1, -1]
+        ).await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+    
+    #[tokio::test]
+    async fn opening_new_order_async_should_work() {
+        let instrument = config::bitwyre_instrument("1");
+        let data = private::opening_new_order_async(instrument, 1, Some(35000.to_string()), 2, "0.0001").await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+        
+        let data = private::opening_new_order_async(instrument, 1, Some("".to_string()), 1, "0.0001").await;
+        assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
+    }
+}

--- a/rust/tests/public.rs
+++ b/rust/tests/public.rs
@@ -4,47 +4,88 @@ mod test {
         public,
         public::config
     };
+    use serde::{Deserialize, Serialize};
+    
+    #[derive(Serialize, Deserialize)]
+    struct ResultString {
+        error: Vec<String>,
+    }
     
     #[tokio::test]
     async fn get_server_time_async_should_work() {
         let data = public::get_server_time_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_markets_async_should_work() {
         let data = public::get_markets_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_products_async_should_work() {
         let data = public::get_products_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_assets_async_should_work() {
         let data = public::get_assets_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_crypto_assets_async_should_work() {
         let data = public::get_crypto_assets_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_fiat_assets_async_should_work() {
         let data = public::get_fiat_assets_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_asset_pairs_async_should_work() {
         let data = public::get_asset_pairs_async("crypto","spot","ID").await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
@@ -52,6 +93,11 @@ mod test {
         let instrument = config::bitwyre_instrument("1");
         let data = public::get_ticker_async(instrument).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
@@ -59,6 +105,11 @@ mod test {
         let instrument = config::bitwyre_instrument("1");
         let data = public::get_trades_async("2", instrument).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
@@ -66,6 +117,11 @@ mod test {
         let instrument = config::bitwyre_instrument("1");
         let data = public::get_depth_async(instrument, "5").await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
@@ -73,42 +129,77 @@ mod test {
         let instrument_contract = config::bitwyre_instrument("7");
         let data = public::get_contract_async(instrument_contract).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_insider_profiles_async_should_work() {
         let data = public::get_insider_profiles_async(None).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_insider_trades_async_should_work() {
         let data = public::get_insider_trades_async(None).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_announcements_async_should_work() {
         let data = public::get_announcements_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_order_types_async_should_work() {
         let data = public::get_order_types_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_languages_async_should_work() {
         let data = public::get_languages_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_search_results_async_should_work() {
         let data = public::get_search_results_async().await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
@@ -116,23 +207,43 @@ mod test {
         let instrument = config::bitwyre_instrument("1");
         let data = public::get_price_index_async(instrument, None, None, None, None).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_search_async_should_work() {
         let data = public::get_search_async("ID", None).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_matching_engine_order_lag_async_should_work() {
         let data = public::get_matching_engine_order_lag_async(None).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
     
     #[tokio::test]
     async fn get_matching_engine_throughput_async_should_work() {
         let data = public::get_matching_engine_throughput_async(None).await;
         assert!(data.is_ok());
+
+        let r: ResultString = serde_json::from_str(
+            &data.unwrap()
+        ).unwrap();
+        assert!(r.error.is_empty());
     }
 }


### PR DESCRIPTION
### Changelog
- Public and private async APIs now return results in the form of a JSON string.
- Update integration tests to check if the error Results are empty.